### PR TITLE
Using tidyverse 4.4.0 as base dev image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,21 +1,13 @@
-FROM rocker/r-devel:latest
+FROM rocker/tidyverse:4.4.0
 
 # RUN \
-#   echo 'options(repos=c(CRAN="https://cloud.r-project.org"))' >> ~/.Rprofile && \
+#   echo 'options(repos=c(CRAN="https://packagemanager.posit.co/cran/__linux__/bookworm/latest"))' >> ~/.Rprofile && \
 #   Rscript --vanilla -e 'getOption("repos")'
 
-# Adding Git
-RUN apt-get update && apt-get install -y --no-install-recommends git
-
 # Adding R packages
-RUN \
-  wget https://github.com/jgm/pandoc/releases/download/3.2.1/pandoc-3.2.1-1-amd64.deb && \
-  dpkg -i pandoc-3.2.1-1-amd64.deb
+RUN install2.r cpp11 roxygen2 tinytest data.table netplot \
+  devtools decor
 
-RUN install2.r cpp11 rmarkdown roxygen2 tinytest data.table netplot \
-  devtools
-
-RUN apt-get install -y --no-install-recommends && \
-  install2.r languageserver
+RUN install2.r languageserver
 
 CMD ["bash"]


### PR DESCRIPTION
Hey @apulsipher, see if this works instead. We can start thinking about the dev version of R later on. We may have a separate workflow in GHA that builds the package for CRAN submission.