### PR TITLE
Passing LFMCMC object to functions and improve docs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -31,7 +31,7 @@ README\.html
 
 # Adding gitattributes
 \.gitattributes
-\.pre-commit-config.yaml
+\.pre-commit-config\.yaml
 
 paper\..+
 docker

--- a/R/LFMCMC.R
+++ b/R/LFMCMC.R
@@ -49,7 +49,7 @@ stopifnot_lfmcmc <- function(x) {
 #' obs_data <- get_today_total(model_sir)
 #'
 #' # Define the simulation function
-#' simfun <- function(params, model) {
+#' simfun <- function(params, lfmcmc_obj) {
 #'   set_param(model_sir, "Recovery rate", params[1])
 #'   set_param(model_sir, "Transmission rate", params[2])
 #'   run(model_sir, ndays = 50)
@@ -58,7 +58,7 @@ stopifnot_lfmcmc <- function(x) {
 #' }
 #'
 #' # Define the summary function
-#' sumfun <- function(dat, model) {
+#' sumfun <- function(dat, lfmcmc_obj) {
 #'   return(dat)
 #' }
 #'

--- a/R/LFMCMC.R
+++ b/R/LFMCMC.R
@@ -12,11 +12,21 @@ stopifnot_lfmcmc <- function(x) {
 #'
 #' @aliases epiworld_lfmcmc
 #' @param model A model of class [epiworld_model] or `NULL` (see details).
+#' @param fun A function (see details).
 #' @details
 #' Performs a Likelihood-Free Markhov Chain Monte Carlo simulation. When
 #' `model` is not `NULL`, the model uses the same random-number generator
 #' engine as the model. Otherwise, when `model` is `NULL`, a new random-number
 #' generator engine is created.
+#'
+#' The functions passed to the LFMCMC object have different arguments depending
+#' on the object:
+#' - `set_proposal_fun`: A vector of parameters and the model.
+#' - `set_simulation_fun`: A vector of parameters and the model.
+#' - `set_summary_fun`: A vector of simulated data and the model.
+#' - `set_kernel_fun`: A vector of simulated statistics, observed statistics,
+#' epsilon, and the model.
+#'
 #' @returns
 #' The `LFMCMC` function returns a model of class [epiworld_lfmcmc].
 #' @examples
@@ -39,7 +49,7 @@ stopifnot_lfmcmc <- function(x) {
 #' obs_data <- get_today_total(model_sir)
 #'
 #' # Define the simulation function
-#' simfun <- function(params) {
+#' simfun <- function(params, model) {
 #'   set_param(model_sir, "Recovery rate", params[1])
 #'   set_param(model_sir, "Transmission rate", params[2])
 #'   run(model_sir, ndays = 50)
@@ -48,7 +58,7 @@ stopifnot_lfmcmc <- function(x) {
 #' }
 #'
 #' # Define the summary function
-#' sumfun <- function(dat) {
+#' sumfun <- function(dat, model) {
 #'   return(dat)
 #' }
 #'
@@ -69,9 +79,9 @@ stopifnot_lfmcmc <- function(x) {
 #' # Run the LFMCMC simulation
 #' run_lfmcmc(
 #'   lfmcmc = lfmcmc_model,
-#'   params_init_ = par0,
-#'   n_samples_ = n_samp,
-#'   epsilon_ = epsil,
+#'   params_init = par0,
+#'   n_samples = n_samp,
+#'   epsilon = epsil,
 #'   seed = model_seed
 #' )
 #'
@@ -102,14 +112,14 @@ LFMCMC <- function(model = NULL) {
 
 #' @rdname LFMCMC
 #' @param lfmcmc LFMCMC model
-#' @param params_init_ Initial model parameters, treated as double
-#' @param n_samples_ Number of samples, treated as integer
-#' @param epsilon_ Epsilon parameter, treated as double
+#' @param params_init Initial model parameters, treated as double
+#' @param n_samples Number of samples, treated as integer
+#' @param epsilon Epsilon parameter, treated as double
 #' @param seed Random engine seed
 #' @returns The simulated model of class [epiworld_lfmcmc].
 #' @export
 run_lfmcmc <- function(
-    lfmcmc, params_init_, n_samples_, epsilon_,
+    lfmcmc, params_init, n_samples, epsilon,
     seed = NULL
     ) {
 
@@ -120,9 +130,9 @@ run_lfmcmc <- function(
 
   run_lfmcmc_cpp(
     lfmcmc,
-    as.double(params_init_),
-    as.integer(n_samples_),
-    as.double(epsilon_),
+    as.double(params_init),
+    as.integer(n_samples),
+    as.double(epsilon),
     sample.int(1e4, 1)
   )
 
@@ -131,27 +141,22 @@ run_lfmcmc <- function(
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc LFMCMC model
-#' @param observed_data_ Observed data, treated as double
-#' @returns The lfmcmc model with the observed data added
+#' @param observed_data Observed data, treated as double.
 #' @export
-set_observed_data <- function(lfmcmc, observed_data_) {
+set_observed_data <- function(lfmcmc, observed_data) {
 
   stopifnot_lfmcmc(lfmcmc)
 
   set_observed_data_cpp(
     lfmcmc,
-    as.double(observed_data_)
+    as.double(observed_data)
   )
 
   invisible(lfmcmc)
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc LFMCMC model
-#' @param fun The LFMCMC proposal function
 #' @export
-#' @returns The lfmcmc model with the proposal function added
 set_proposal_fun <- function(lfmcmc, fun) {
 
   stopifnot_lfmcmc(lfmcmc)
@@ -161,8 +166,6 @@ set_proposal_fun <- function(lfmcmc, fun) {
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc The LFMCMC model
-#' @returns The LFMCMC model with proposal function set to norm reflective
 #' @export
 use_proposal_norm_reflective <- function(lfmcmc) {
 
@@ -173,9 +176,6 @@ use_proposal_norm_reflective <- function(lfmcmc) {
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc LFMCMC model
-#' @param fun The LFMCMC simulation function
-#' @returns The lfmcmc model with the simulation function added
 #' @export
 set_simulation_fun <- function(lfmcmc, fun) {
 
@@ -186,9 +186,6 @@ set_simulation_fun <- function(lfmcmc, fun) {
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc LFMCMC model
-#' @param fun The LFMCMC sumamry function
-#' @returns The lfmcmc model with the summary function added
 #' @export
 set_summary_fun <- function(lfmcmc, fun) {
 
@@ -199,9 +196,6 @@ set_summary_fun <- function(lfmcmc, fun) {
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc LFMCMC model
-#' @param fun The LFMCMC kernel function
-#' @returns The lfmcmc model with the kernel function added
 #' @export
 set_kernel_fun <- function(lfmcmc, fun) {
 
@@ -212,8 +206,9 @@ set_kernel_fun <- function(lfmcmc, fun) {
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc The LFMCMC model
-#' @returns The LFMCMC model with kernel function set to gaussian
+#' @returns
+#' - `use_kernel_fun_gaussian`: The LFMCMC model with kernel function set to
+#' gaussian.
 #' @export
 use_kernel_fun_gaussian <- function(lfmcmc) {
 
@@ -224,9 +219,9 @@ use_kernel_fun_gaussian <- function(lfmcmc) {
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc LFMCMC model
-#' @param names The model parameter names
-#' @returns The lfmcmc model with the parameter names added
+#' @param names Character vector of names.
+#' @returns
+#' - `set_params_names`: The lfmcmc model with the parameter names added.
 #' @export
 set_params_names <- function(lfmcmc, names) {
 
@@ -237,9 +232,8 @@ set_params_names <- function(lfmcmc, names) {
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc LFMCMC model
-#' @param names The model stats names
-#' @returns The lfmcmc model with the stats names added
+#' @returns
+#' - `set_stats_names`: The lfmcmc model with the stats names added.
 #' @export
 set_stats_names <- function(lfmcmc, names) {
 
@@ -250,8 +244,8 @@ set_stats_names <- function(lfmcmc, names) {
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc LFMCMC model
-#' @returns The param means for the given lfmcmc model
+#' @returns
+#' - `get_mean_params`: The param means for the given lfmcmc model.
 #' @export
 get_mean_params <- function(lfmcmc) {
 
@@ -261,8 +255,8 @@ get_mean_params <- function(lfmcmc) {
 }
 
 #' @rdname LFMCMC
-#' @param lfmcmc LFMCMC model
-#' @returns The stats means for the given lfmcmc model
+#' @returns
+#' - `get_mean_stats`: The stats means for the given lfmcmc model.
 #' @export
 get_mean_stats <- function(lfmcmc) {
 
@@ -274,8 +268,8 @@ get_mean_stats <- function(lfmcmc) {
 #' @rdname LFMCMC
 #' @param x LFMCMC model to print
 #' @param ... Ignored
-#' @param burnin Integer. Number of samples to discard as burnin before computing the summary.
-#' @returns The lfmcmc model
+#' @param burnin Integer. Number of samples to discard as burnin before
+#' computing the summary.
 #' @export
 print.epiworld_lfmcmc <- function(x, burnin = 0, ...) {
 

--- a/inst/tinytest/test-lfmcmc.R
+++ b/inst/tinytest/test-lfmcmc.R
@@ -29,7 +29,7 @@ obs_data <- get_today_total(model_sir)
 expect_silent(set_observed_data(lfmcmc_model, obs_data))
 
 # Define LFMCMC functions
-simfun <- function(params, model) {
+simfun <- function(params, lfmcmc_obj) {
   set_param(model_sir, "Recovery rate", params[1])
   set_param(model_sir, "Transmission rate", params[2])
   run(model_sir, ndays = 50)
@@ -37,14 +37,14 @@ simfun <- function(params, model) {
   return(res)
 }
 
-sumfun <- function(dat, model) { return(dat) }
+sumfun <- function(dat, lfmcmc_obj) { return(dat) }
 
-propfun <- function(old_params, model) {
+propfun <- function(old_params, lfmcmc_obj) {
   res <- plogis(qlogis(old_params) + rnorm(length(old_params)))
   return(res)
 }
 
-kernelfun <- function(simulated_stats, observed_stats, epsilon, model) {
+kernelfun <- function(simulated_stats, observed_stats, epsilon, lfmcmc_obj) {
   dnorm(sqrt(sum((simulated_stats - observed_stats)^2)))
 }
 
@@ -161,15 +161,15 @@ set.seed(model_seed)
 Y <- rnorm(2000, mean = -5, sd = 2.5)
 
 # Define LFMCMC functions
-simfun <- function(par, model) {
+simfun <- function(par, lfmcmc_obj) {
   rnorm(2000, mean = par[1], sd = par[2])
 }
 
-sumfun <- function(x, model) {
+sumfun <- function(x, lfmcmc_obj) {
   c(mean(x), sd(x))
 }
 
-propfun <- function(par, model) {
+propfun <- function(par, lfmcmc_obj) {
   
   par_new <- par + rnorm(2, sd = 0.1)
 
@@ -181,7 +181,7 @@ propfun <- function(par, model) {
   return(par_new)
 }
 
-kernelfun <- function(simulated_stats, observed_stats, epsilon, model) {
+kernelfun <- function(simulated_stats, observed_stats, epsilon, lfmcmc_obj) {
 
   dnorm(sqrt(sum((observed_stats - simulated_stats)^2)))
   

--- a/inst/tinytest/test-lfmcmc.R
+++ b/inst/tinytest/test-lfmcmc.R
@@ -29,7 +29,7 @@ obs_data <- get_today_total(model_sir)
 expect_silent(set_observed_data(lfmcmc_model, obs_data))
 
 # Define LFMCMC functions
-simfun <- function(params) {
+simfun <- function(params, model) {
   set_param(model_sir, "Recovery rate", params[1])
   set_param(model_sir, "Transmission rate", params[2])
   run(model_sir, ndays = 50)
@@ -37,14 +37,14 @@ simfun <- function(params) {
   return(res)
 }
 
-sumfun <- function(dat) { return(dat) }
+sumfun <- function(dat, model) { return(dat) }
 
-propfun <- function(old_params) {
+propfun <- function(old_params, model) {
   res <- plogis(qlogis(old_params) + rnorm(length(old_params)))
   return(res)
 }
 
-kernelfun <- function(simulated_stats, observed_stats, epsilon) {
+kernelfun <- function(simulated_stats, observed_stats, epsilon, model) {
   dnorm(sqrt(sum((simulated_stats - observed_stats)^2)))
 }
 
@@ -62,9 +62,9 @@ epsil <- 1.0
 
 expect_silent(run_lfmcmc(
   lfmcmc = lfmcmc_model,
-  params_init_ = par0,
-  n_samples_ = n_samp,
-  epsilon_ = epsil,
+  params_init = par0,
+  n_samples = n_samp,
+  epsilon = epsil,
   seed = model_seed
 ))
 
@@ -99,9 +99,9 @@ expect_silent(use_kernel_fun_gaussian(lfmcmc_model))
 
 expect_silent(run_lfmcmc(
   lfmcmc = lfmcmc_model,
-  params_init_ = par0,
-  n_samples_ = n_samp,
-  epsilon_ = epsil,
+  params_init = par0,
+  n_samples = n_samp,
+  epsilon = epsil,
   seed = model_seed
 ))
 
@@ -115,42 +115,42 @@ epsil_int <- as.integer(1)
 
 expect_silent(run_lfmcmc(
   lfmcmc = lfmcmc_model,
-  params_init_ = par0_int,
-  n_samples_ = n_samp_double,
-  epsilon_ = epsil_int,
+  params_init = par0_int,
+  n_samples = n_samp_double,
+  epsilon = epsil_int,
   seed = model_seed
 ))
 
 # Check running LFMCMC with missing parameters ---------------------------------
 expect_silent(run_lfmcmc(
   lfmcmc = lfmcmc_model,
-  params_init_ = par0,
-  n_samples_ = n_samp,
-  epsilon_ = epsil
+  params_init = par0,
+  n_samples = n_samp,
+  epsilon = epsil
 ))
 
 expect_error(run_lfmcmc(
   lfmcmc = lfmcmc_model,
-  params_init_ = par0,
-  n_samples_ = n_samp
+  params_init = par0,
+  n_samples = n_samp
 ))
 
 expect_error(run_lfmcmc(
   lfmcmc = lfmcmc_model,
-  params_init_ = par0,
-  epsilon_ = epsil
+  params_init = par0,
+  epsilon = epsil
 ))
 
 expect_error(run_lfmcmc(
   lfmcmc = lfmcmc_model,
-  n_samples_ = n_samp,
-  epsilon_ = epsil
+  n_samples = n_samp,
+  epsilon = epsil
 ))
 
 expect_error(run_lfmcmc(
-  params_init_ = par0,
-  n_samples_ = n_samp,
-  epsilon_ = epsil
+  params_init = par0,
+  n_samples = n_samp,
+  epsilon = epsil
 ))
 
 expect_error(run_lfmcmc(lfmcmc = lfmcmc_model))
@@ -161,15 +161,15 @@ set.seed(model_seed)
 Y <- rnorm(2000, mean = -5, sd = 2.5)
 
 # Define LFMCMC functions
-simfun <- function(par) {
+simfun <- function(par, model) {
   rnorm(2000, mean = par[1], sd = par[2])
 }
 
-sumfun <- function(x) {
+sumfun <- function(x, model) {
   c(mean(x), sd(x))
 }
 
-propfun <- function(par) {
+propfun <- function(par, model) {
   
   par_new <- par + rnorm(2, sd = 0.1)
 
@@ -181,7 +181,7 @@ propfun <- function(par) {
   return(par_new)
 }
 
-kernelfun <- function(simulated_stats, observed_stats, epsilon) {
+kernelfun <- function(simulated_stats, observed_stats, epsilon, model) {
 
   dnorm(sqrt(sum((observed_stats - simulated_stats)^2)))
   
@@ -198,9 +198,9 @@ lfmcmc_model <- LFMCMC() |>
 # Run LFMCMC
 x <- run_lfmcmc(
   lfmcmc = lfmcmc_model,
-  params_init_ = c(0, 1),
-  n_samples_ = 3000,
-  epsilon_ = 1.0,
+  params_init = c(0, 1),
+  n_samples = 3000,
+  epsilon = 1.0,
   seed = model_seed
 )
 
@@ -218,9 +218,9 @@ expected_error_msg <- "must be an object of class epiworld_lfmcmc"
 not_lfmcmc <- c("NOT LFMCMC")
 
 expect_error(run_lfmcmc(not_lfmcmc,
-                        params_init_ = par0_int,
-                        n_samples_ = n_samp_double,
-                        epsilon_ = epsil_int,
+                        params_init = par0_int,
+                        n_samples = n_samp_double,
+                        epsilon = epsil_int,
                         seed = model_seed
                         ), expected_error_msg)
 

--- a/man/LFMCMC.Rd
+++ b/man/LFMCMC.Rd
@@ -180,7 +180,7 @@ run(model_sir, ndays = 50, seed = model_seed)
 obs_data <- get_today_total(model_sir)
 
 # Define the simulation function
-simfun <- function(params, model) {
+simfun <- function(params, lfmcmc_obj) {
   set_param(model_sir, "Recovery rate", params[1])
   set_param(model_sir, "Transmission rate", params[2])
   run(model_sir, ndays = 50)
@@ -189,7 +189,7 @@ simfun <- function(params, model) {
 }
 
 # Define the summary function
-sumfun <- function(dat, model) {
+sumfun <- function(dat, lfmcmc_obj) {
   return(dat)
 }
 

--- a/man/LFMCMC.Rd
+++ b/man/LFMCMC.Rd
@@ -26,9 +26,9 @@
 \usage{
 LFMCMC(model = NULL)
 
-run_lfmcmc(lfmcmc, params_init_, n_samples_, epsilon_, seed = NULL)
+run_lfmcmc(lfmcmc, params_init, n_samples, epsilon, seed = NULL)
 
-set_observed_data(lfmcmc, observed_data_)
+set_observed_data(lfmcmc, observed_data)
 
 set_proposal_fun(lfmcmc, fun)
 
@@ -69,23 +69,24 @@ get_n_samples(lfmcmc)
 
 \item{lfmcmc}{LFMCMC model}
 
-\item{params_init_}{Initial model parameters, treated as double}
+\item{params_init}{Initial model parameters, treated as double}
 
-\item{n_samples_}{Number of samples, treated as integer}
+\item{n_samples}{Number of samples, treated as integer}
 
-\item{epsilon_}{Epsilon parameter, treated as double}
+\item{epsilon}{Epsilon parameter, treated as double}
 
 \item{seed}{Random engine seed}
 
-\item{observed_data_}{Observed data, treated as double}
+\item{observed_data}{Observed data, treated as double.}
 
-\item{fun}{The LFMCMC kernel function}
+\item{fun}{A function (see details).}
 
-\item{names}{The model stats names}
+\item{names}{Character vector of names.}
 
 \item{x}{LFMCMC model to print}
 
-\item{burnin}{Integer. Number of samples to discard as burnin before computing the summary.}
+\item{burnin}{Integer. Number of samples to discard as burnin before
+computing the summary.}
 
 \item{...}{Ignored}
 }
@@ -94,29 +95,26 @@ The \code{LFMCMC} function returns a model of class \link{epiworld_lfmcmc}.
 
 The simulated model of class \link{epiworld_lfmcmc}.
 
-The lfmcmc model with the observed data added
+\itemize{
+\item \code{use_kernel_fun_gaussian}: The LFMCMC model with kernel function set to
+gaussian.
+}
 
-The lfmcmc model with the proposal function added
+\itemize{
+\item \code{set_params_names}: The lfmcmc model with the parameter names added.
+}
 
-The LFMCMC model with proposal function set to norm reflective
+\itemize{
+\item \code{set_stats_names}: The lfmcmc model with the stats names added.
+}
 
-The lfmcmc model with the simulation function added
+\itemize{
+\item \code{get_mean_params}: The param means for the given lfmcmc model.
+}
 
-The lfmcmc model with the summary function added
-
-The lfmcmc model with the kernel function added
-
-The LFMCMC model with kernel function set to gaussian
-
-The lfmcmc model with the parameter names added
-
-The lfmcmc model with the stats names added
-
-The param means for the given lfmcmc model
-
-The stats means for the given lfmcmc model
-
-The lfmcmc model
+\itemize{
+\item \code{get_mean_stats}: The stats means for the given lfmcmc model.
+}
 
 \itemize{
 \item The function \code{get_accepted_params} returns a matrix of accepted
@@ -151,6 +149,16 @@ Performs a Likelihood-Free Markhov Chain Monte Carlo simulation. When
 \code{model} is not \code{NULL}, the model uses the same random-number generator
 engine as the model. Otherwise, when \code{model} is \code{NULL}, a new random-number
 generator engine is created.
+
+The functions passed to the LFMCMC object have different arguments depending
+on the object:
+\itemize{
+\item \code{set_proposal_fun}: A vector of parameters and the model.
+\item \code{set_simulation_fun}: A vector of parameters and the model.
+\item \code{set_summary_fun}: A vector of simulated data and the model.
+\item \code{set_kernel_fun}: A vector of simulated statistics, observed statistics,
+epsilon, and the model.
+}
 }
 \examples{
 ## Setup an SIR model to use in the simulation
@@ -172,7 +180,7 @@ run(model_sir, ndays = 50, seed = model_seed)
 obs_data <- get_today_total(model_sir)
 
 # Define the simulation function
-simfun <- function(params) {
+simfun <- function(params, model) {
   set_param(model_sir, "Recovery rate", params[1])
   set_param(model_sir, "Transmission rate", params[2])
   run(model_sir, ndays = 50)
@@ -181,7 +189,7 @@ simfun <- function(params) {
 }
 
 # Define the summary function
-sumfun <- function(dat) {
+sumfun <- function(dat, model) {
   return(dat)
 }
 
@@ -202,9 +210,9 @@ epsil <- 1.0
 # Run the LFMCMC simulation
 run_lfmcmc(
   lfmcmc = lfmcmc_model,
-  params_init_ = par0,
-  n_samples_ = n_samp,
-  epsilon_ = epsil,
+  params_init = par0,
+  n_samples = n_samp,
+  epsilon = epsil,
   seed = model_seed
 )
 

--- a/src/lfmcmc.cpp
+++ b/src/lfmcmc.cpp
@@ -148,11 +148,13 @@ SEXP set_summary_fun_cpp(
     LFMCMCSummaryFun<TData_default> fun_call = [fun](
         std::vector< epiworld_double >& res,
         const TData_default& dat,
-        LFMCMC<TData_default>*
+        LFMCMC<TData_default>* lfmcmc_obj
         ) -> void {
 
         auto dat_int = cpp11::doubles(dat);
-        auto res_tmp = cpp11::doubles(fun(dat_int));
+        WrapLFMCMC(lfmcmc_ptr)(lfmcmc_obj, false);
+        auto res_tmp = cpp11::doubles(fun(dat_int, lfmcmc_ptr));
+
 
         if (res.size() == 0u)
             res.resize(res_tmp.size());
@@ -185,10 +187,7 @@ SEXP set_kernel_fun_cpp(
         auto sim_stats_doubles = cpp11::doubles(simulated_stats);
         auto obs_stats_doubles = cpp11::doubles(observed_stats);
 
-        cpp11::external_pointer<LFMCMC<TData_default>> lfmcmc_ptr(
-            lfmcmc_obj,
-            false
-            );
+        WrapLFMCMC(lfmcmc_ptr)(lfmcmc_obj, false);
 
         return cpp11::as_cpp<epiworld_double>(
             fun(sim_stats_doubles, obs_stats_doubles, epsilon, lfmcmc_ptr)

--- a/src/lfmcmc.cpp
+++ b/src/lfmcmc.cpp
@@ -179,14 +179,19 @@ SEXP set_kernel_fun_cpp(
         const std::vector< epiworld_double >& simulated_stats,
         const std::vector< epiworld_double >& observed_stats,
         epiworld_double epsilon,
-        LFMCMC<TData_default>*
+        LFMCMC<TData_default> * lfmcmc_obj
         ) -> epiworld_double {
 
         auto sim_stats_doubles = cpp11::doubles(simulated_stats);
         auto obs_stats_doubles = cpp11::doubles(observed_stats);
 
+        cpp11::external_pointer<LFMCMC<TData_default>> lfmcmc_ptr(
+            lfmcmc_obj,
+            false
+            );
+
         return cpp11::as_cpp<epiworld_double>(
-            fun(sim_stats_doubles, obs_stats_doubles, epsilon)
+            fun(sim_stats_doubles, obs_stats_doubles, epsilon, lfmcmc_ptr)
             );
     };
 

--- a/src/lfmcmc.cpp
+++ b/src/lfmcmc.cpp
@@ -14,8 +14,12 @@ using namespace epiworld;
 #define WrapLFMCMC(a) \
     cpp11::external_pointer<LFMCMC<TData_default>> (a)
 
-#define SetClassAttr(a) \
-    attr((a), "class") = "epiworld_lfmcmc"
+inline cpp11::sexp lfmcmc_as_sexp(LFMCMC<TData_default> * lfmcmc) {
+    WrapLFMCMC(lfmcmc_ptr)(lfmcmc, false);
+    cpp11::sexp lfmcmc_ptr_s(lfmcmc_ptr);
+    lfmcmc_ptr_s.attr("class") = "epiworld_lfmcmc";
+    return lfmcmc_ptr_s;
+}
 
 // LFMCMC definitions:
 // https://github.com/UofUEpiBio/epiworld/tree/master/include/epiworld/math/lfmcmc
@@ -88,8 +92,7 @@ SEXP set_proposal_fun_cpp(
         ) -> void {
 
         auto params_doubles = cpp11::doubles(old_params);
-        WrapLFMCMC(lfmcmc_ptr)(lfmcmc_obj, false);
-        SetClassAttr(lfmcmc_ptr);
+        auto lfmcmc_ptr = lfmcmc_as_sexp(lfmcmc_obj);
         auto res_tmp = cpp11::doubles(fun(params_doubles, lfmcmc_ptr));
 
         std::copy(
@@ -130,8 +133,7 @@ SEXP set_simulation_fun_cpp(
         ) -> TData_default {
 
         auto params_doubles = cpp11::doubles(params);
-        WrapLFMCMC(lfmcmc_ptr)(lfmcmc_obj, false);
-        SetClassAttr(lfmcmc_ptr);
+        auto lfmcmc_ptr = lfmcmc_as_sexp(lfmcmc_obj);
         return cpp11::as_cpp<TData_default>(
             cpp11::doubles(fun(params_doubles, lfmcmc_ptr))
             );
@@ -157,8 +159,7 @@ SEXP set_summary_fun_cpp(
         ) -> void {
 
         auto dat_int = cpp11::doubles(dat);
-        WrapLFMCMC(lfmcmc_ptr)(lfmcmc_obj, false);
-        SetClassAttr(lfmcmc_ptr);
+        auto lfmcmc_ptr = lfmcmc_as_sexp(lfmcmc_obj);
         auto res_tmp = cpp11::doubles(fun(dat_int, lfmcmc_ptr));
 
 
@@ -193,8 +194,7 @@ SEXP set_kernel_fun_cpp(
         auto sim_stats_doubles = cpp11::doubles(simulated_stats);
         auto obs_stats_doubles = cpp11::doubles(observed_stats);
 
-        WrapLFMCMC(lfmcmc_ptr)(lfmcmc_obj, false);
-        SetClassAttr(lfmcmc_ptr);
+        auto lfmcmc_ptr = lfmcmc_as_sexp(lfmcmc_obj);
 
         return cpp11::as_cpp<epiworld_double>(
             fun(sim_stats_doubles, obs_stats_doubles, epsilon, lfmcmc_ptr)
@@ -317,4 +317,3 @@ int get_n_params_cpp(SEXP lfmcmc) {
 }
 
 #undef WrapLFMCMC
-#undef SetClassAttr

--- a/src/lfmcmc.cpp
+++ b/src/lfmcmc.cpp
@@ -14,6 +14,9 @@ using namespace epiworld;
 #define WrapLFMCMC(a) \
     cpp11::external_pointer<LFMCMC<TData_default>> (a)
 
+#define SetClassAttr(a) \
+    attr((a), "class") = "epiworld_lfmcmc"
+
 // LFMCMC definitions:
 // https://github.com/UofUEpiBio/epiworld/tree/master/include/epiworld/math/lfmcmc
 
@@ -81,12 +84,13 @@ SEXP set_proposal_fun_cpp(
     LFMCMCProposalFun<TData_default> fun_call = [fun](
         std::vector< epiworld_double >& new_params,
         const std::vector< epiworld_double >& old_params,
-        LFMCMC<TData_default>*
+        LFMCMC<TData_default> * lfmcmc_obj
         ) -> void {
 
         auto params_doubles = cpp11::doubles(old_params);
-
-        auto res_tmp = cpp11::doubles(fun(params_doubles));
+        WrapLFMCMC(lfmcmc_ptr)(lfmcmc_obj, false);
+        SetClassAttr(lfmcmc_ptr);
+        auto res_tmp = cpp11::doubles(fun(params_doubles, lfmcmc_ptr));
 
         std::copy(
             res_tmp.begin(),
@@ -122,13 +126,14 @@ SEXP set_simulation_fun_cpp(
 
     LFMCMCSimFun<TData_default> fun_call = [fun](
         const std::vector<epiworld_double>& params,
-        LFMCMC<TData_default>*
+        LFMCMC<TData_default> * lfmcmc_obj
         ) -> TData_default {
 
         auto params_doubles = cpp11::doubles(params);
-
+        WrapLFMCMC(lfmcmc_ptr)(lfmcmc_obj, false);
+        SetClassAttr(lfmcmc_ptr);
         return cpp11::as_cpp<TData_default>(
-            cpp11::doubles(fun(params_doubles))
+            cpp11::doubles(fun(params_doubles, lfmcmc_ptr))
             );
     };
 
@@ -153,6 +158,7 @@ SEXP set_summary_fun_cpp(
 
         auto dat_int = cpp11::doubles(dat);
         WrapLFMCMC(lfmcmc_ptr)(lfmcmc_obj, false);
+        SetClassAttr(lfmcmc_ptr);
         auto res_tmp = cpp11::doubles(fun(dat_int, lfmcmc_ptr));
 
 
@@ -188,6 +194,7 @@ SEXP set_kernel_fun_cpp(
         auto obs_stats_doubles = cpp11::doubles(observed_stats);
 
         WrapLFMCMC(lfmcmc_ptr)(lfmcmc_obj, false);
+        SetClassAttr(lfmcmc_ptr);
 
         return cpp11::as_cpp<epiworld_double>(
             fun(sim_stats_doubles, obs_stats_doubles, epsilon, lfmcmc_ptr)
@@ -310,3 +317,4 @@ int get_n_params_cpp(SEXP lfmcmc) {
 }
 
 #undef WrapLFMCMC
+#undef SetClassAttr

--- a/vignettes/likelihood-free-mcmc.Rmd
+++ b/vignettes/likelihood-free-mcmc.Rmd
@@ -108,7 +108,7 @@ For our example, since the population distribution is already a summary of the d
 With more complicated use cases, you might instead compute summary statistics such as the mean or standard deviation.
 
 ```{r sumfun}
-summary_fun <- function(data) {
+summary_fun <- function(data, model) {
   return(data)
 }
 ```
@@ -126,8 +126,9 @@ proposal_fun <- function(old_params) {
 The **kernel function** effectively scores the results of the latest simulation run against the observed data, by comparing the summary statistics from `summary_fun` for each.
 LFMCMC uses the kernel score and the Hastings Ratio to determine whether or not to accept the parameters for that run.
 In our example, since `summary_fun` simply passes the data through, `simulated_stats` and `observed_stats` are our simulated and observed data respectively.
+
 ```{r kernfun}
-kernel_fun <- function(simulated_stats, observed_stats, epsilon) {
+kernel_fun <- function(simulated_stats, observed_stats, epsilon, model) {
   dnorm(sqrt(sum((simulated_stats - observed_stats)^2)))
 }
 ```

--- a/vignettes/likelihood-free-mcmc.Rmd
+++ b/vignettes/likelihood-free-mcmc.Rmd
@@ -16,15 +16,16 @@ knitr::opts_chunk$set(
   fig.align = "center"
 )
 ```
+
 # Introduction
-The purpose of the "LFMCMC" class in epiworldR is to perform a Likelihood-Free Markhov Chain Monte Carlo (LFMCMC) simulation.
-LFMCMC is used to approximate models where the likelihood function is either unavailable or computationally expensive.
-This example assumes a general understanding of LFMCMC.
-To learn more about it, see the Handbook of Markhov Chain Monte Carlo by Brooks et al. (https://doi.org/10.1201/b10905).
+
+The purpose of the "LFMCMC" class in epiworldR is to perform a Likelihood-Free Markhov Chain Monte Carlo (LFMCMC) simulation. LFMCMC is used to approximate models where the likelihood function is either unavailable or computationally expensive. This example assumes a general understanding of LFMCMC.
+To learn more about it, see the Handbook of Markhov Chain Monte Carlo by Brooks et al. <https://doi.org/10.1201/b10905>.
 
 In this example, we use LFMCMC to recover the parameters of an SIR model.
 
 # Setup The SIR Model
+
 Our SIR model will have the following characteristics:
 
 * **Virus Name:** COVID-19
@@ -34,6 +35,7 @@ Our SIR model will have the following characteristics:
 * **Number of Agents:** 1,000
 
 We use the `ModelSIR` and `agents_smallworld` functions to construct the model in epiworldR.
+
 ```{r setup-sir}
 library(epiworldR)
 
@@ -56,6 +58,7 @@ agents_smallworld(
 ```
 
 Then we run the model for 50 days and print the results.
+
 ```{r run-sir}
 verbose_off(model_sir)
 
@@ -68,26 +71,22 @@ run(
 summary(model_sir)
 ```
 
-Note the "Model parameters" and the "Distribution of the population at time 50" from the above output.
-Our goal is to recover the model parameters (Recovery and Transmission rates) through LFMCMC.
-We accomplish this by comparing the population distribution from each simulation run to the "observed" distribution from our model.
-We get this distribution using the `get_today_total` function in epiworldR.
+Note the "Model parameters" and the "Distribution of the population at time 50" from the above output. Our goal is to recover the model parameters (Recovery and Transmission rates) through LFMCMC. We accomplish this by comparing the population distribution from each simulation run to the "observed" distribution from our model. We get this distribution using the `get_today_total` function in epiworldR.
+
 ```{r get-sir-model-data}
 model_sir_data <- get_today_total(model_sir)
 ```
 
-For practical cases, you would use observed data, instead of a model simulation.
-We use a simulation in our example to show the accuracy of LFMCMC in recovering the model parameters.
-Whenever we use the term "observed data" below, we are referring to the model distribution ().
+For practical cases, you would use observed data, instead of a model simulation. We use a simulation in our example to show the accuracy of LFMCMC in recovering the model parameters. Whenever we use the term "observed data" below, we are referring to the model distribution ().
 
 # Setup LFMCMC
+
 In epiworldR, LFMCMC requires four functions:
 
-The **simulation function** runs a model with a given set of parameters and produces output that matches the structure of our observed data.
-For our example, we set the Recovery and Transmission rate parameters, run an SIR model for 50 days, and return the distribution of the population at the end of the run.
+The **simulation function** runs a model with a given set of parameters and produces output that matches the structure of our observed data. For our example, we set the Recovery and Transmission rate parameters, run an SIR model for 50 days, and return the distribution of the population at the end of the run.
 
 ```{r simfun}
-simulation_fun <- function(params) {
+simulation_fun <- function(params, model) {
 
   set_param(model_sir, "Recovery rate", params[1])
   set_param(model_sir, "Transmission rate", params[2])
@@ -103,9 +102,7 @@ simulation_fun <- function(params) {
 ```
 
 The **summary function** extracts summary statistics from the given data.
-This should produce the same output format for both the observed data and the simulated data from `simulation_fun`.
-For our example, since the population distribution is already a summary of the data, our summary function simply passes that data through.
-With more complicated use cases, you might instead compute summary statistics such as the mean or standard deviation.
+This should produce the same output format for both the observed data and the simulated data from `simulation_fun`. For our example, since the population distribution is already a summary of the data, our summary function simply passes that data through. With more complicated use cases, you might instead compute summary statistics such as the mean or standard deviation.
 
 ```{r sumfun}
 summary_fun <- function(data, model) {
@@ -113,19 +110,16 @@ summary_fun <- function(data, model) {
 }
 ```
 
-The **proposal function** returns a new set of parameters, which it is "proposing" parameters for the LFMCMC algorithm to try in the simulation function.
-In our example, it takes the parameters from the previous run (`old_params`) and does a random step away from those values.
+The **proposal function** returns a new set of parameters, which it is "proposing" parameters for the LFMCMC algorithm to try in the simulation function. In our example, it takes the parameters from the previous run (`old_params`) and does a random step away from those values.
 
 ```{r propfun}
-proposal_fun <- function(old_params) {
+proposal_fun <- function(old_params, model) {
   res <- plogis(qlogis(old_params) + rnorm(length(old_params)))
   return(res)
 }
 ```
 
-The **kernel function** effectively scores the results of the latest simulation run against the observed data, by comparing the summary statistics from `summary_fun` for each.
-LFMCMC uses the kernel score and the Hastings Ratio to determine whether or not to accept the parameters for that run.
-In our example, since `summary_fun` simply passes the data through, `simulated_stats` and `observed_stats` are our simulated and observed data respectively.
+The **kernel function** effectively scores the results of the latest simulation run against the observed data, by comparing the summary statistics from `summary_fun` for each. LFMCMC uses the kernel score and the Hastings Ratio to determine whether or not to accept the parameters for that run. In our example, since `summary_fun` simply passes the data through, `simulated_stats` and `observed_stats` are our simulated and observed data respectively.
 
 ```{r kernfun}
 kernel_fun <- function(simulated_stats, observed_stats, epsilon, model) {
@@ -134,6 +128,7 @@ kernel_fun <- function(simulated_stats, observed_stats, epsilon, model) {
 ```
 
 With all four functions defined, we can initialize the simulation object using the `LFMCMC` function in epiworldR along with the appropriate setter functions.
+
 ```{r lfmcmc-setup}
 lfmcmc_model <- LFMCMC(model_sir) |>
   set_simulation_fun(simulation_fun) |>
@@ -144,9 +139,8 @@ lfmcmc_model <- LFMCMC(model_sir) |>
 ```
 
 # Run LFMCMC Simulation
-To run LFMCMC, we need to set the initial model parameters.
-For our example, we use an initial Recovery rate of 0.1 and an initial Transmission rate of 0.5.
-We set the kernel epsilon to 1.0 and run the simulation for 2,000 samples (iterations) using the `run_lfmcmc` function.
+
+To run LFMCMC, we need to set the initial model parameters. For our example, we use an initial Recovery rate of 0.1 and an initial Transmission rate of 0.5. We set the kernel epsilon to 1.0 and run the simulation for 2,000 samples (iterations) using the `run_lfmcmc` function.
 
 ```{r lfmcmc-run}
 initial_params <- c(0.1, 0.5)
@@ -155,16 +149,16 @@ n_samples <- 2000
 
 run_lfmcmc(
   lfmcmc = lfmcmc_model,
-  params_init_ = initial_params,
-  n_samples_ = n_samples,
-  epsilon_ = epsilon,
+  params_init = initial_params,
+  n_samples = n_samples,
+  epsilon = epsilon,
   seed = model_seed
 )
 ```
 
 # Results
-To make the printed results easier to read, we use the `set_params_names` and `set_stats_names` functions before calling `print`.
-We also use a burn-in period of 500 samples.
+To make the printed results easier to read, we use the `set_params_names` and `set_stats_names` functions before calling `print`. We also use a burn-in period of 500 samples.
+
 ```{r lfmcmc-print}
 set_params_names(lfmcmc_model, c("Recovery rate", "Transmission rate"))
 set_stats_names(lfmcmc_model, get_states(model_sir))
@@ -172,6 +166,4 @@ set_stats_names(lfmcmc_model, get_states(model_sir))
 print(lfmcmc_model, burnin = 500)
 ```
 
-Recall that the observed data came from a model with a Recovery rate of 0.3 and a Transmission rate of 0.3.
-As the above output shows, LFMCMC made a close approximation of the parameters, which resulted in a close approximation of the observed population distribution.
-This example highlights the effectiveness of using LFMCMC for highly complex models.
+Recall that the observed data came from a model with a Recovery rate of 0.3 and a Transmission rate of 0.3. As the above output shows, LFMCMC made a close approximation of the parameters, which resulted in a close approximation of the observed population distribution. This example highlights the effectiveness of using LFMCMC for highly complex models.

--- a/vignettes/likelihood-free-mcmc.Rmd
+++ b/vignettes/likelihood-free-mcmc.Rmd
@@ -77,7 +77,7 @@ Note the "Model parameters" and the "Distribution of the population at time 50" 
 model_sir_data <- get_today_total(model_sir)
 ```
 
-For practical cases, you would use observed data, instead of a model simulation. We use a simulation in our example to show the accuracy of LFMCMC in recovering the model parameters. Whenever we use the term "observed data" below, we are referring to the model distribution ().
+For practical cases, you would use observed data, instead of a model simulation. We use a simulation in our example to show the accuracy of LFMCMC in recovering the model parameters. Whenever we use the term "observed data" below, we are referring to the model distribution (`model_sir_data`).
 
 # Setup LFMCMC
 
@@ -86,7 +86,7 @@ In epiworldR, LFMCMC requires four functions:
 The **simulation function** runs a model with a given set of parameters and produces output that matches the structure of our observed data. For our example, we set the Recovery and Transmission rate parameters, run an SIR model for 50 days, and return the distribution of the population at the end of the run.
 
 ```{r simfun}
-simulation_fun <- function(params, model) {
+simulation_fun <- function(params, lfmcmc_obj) {
 
   set_param(model_sir, "Recovery rate", params[1])
   set_param(model_sir, "Transmission rate", params[2])
@@ -105,7 +105,7 @@ The **summary function** extracts summary statistics from the given data.
 This should produce the same output format for both the observed data and the simulated data from `simulation_fun`. For our example, since the population distribution is already a summary of the data, our summary function simply passes that data through. With more complicated use cases, you might instead compute summary statistics such as the mean or standard deviation.
 
 ```{r sumfun}
-summary_fun <- function(data, model) {
+summary_fun <- function(data, lfmcmc_obj) {
   return(data)
 }
 ```
@@ -113,7 +113,7 @@ summary_fun <- function(data, model) {
 The **proposal function** returns a new set of parameters, which it is "proposing" parameters for the LFMCMC algorithm to try in the simulation function. In our example, it takes the parameters from the previous run (`old_params`) and does a random step away from those values.
 
 ```{r propfun}
-proposal_fun <- function(old_params, model) {
+proposal_fun <- function(old_params, lfmcmc_obj) {
   res <- plogis(qlogis(old_params) + rnorm(length(old_params)))
   return(res)
 }
@@ -122,7 +122,7 @@ proposal_fun <- function(old_params, model) {
 The **kernel function** effectively scores the results of the latest simulation run against the observed data, by comparing the summary statistics from `summary_fun` for each. LFMCMC uses the kernel score and the Hastings Ratio to determine whether or not to accept the parameters for that run. In our example, since `summary_fun` simply passes the data through, `simulated_stats` and `observed_stats` are our simulated and observed data respectively.
 
 ```{r kernfun}
-kernel_fun <- function(simulated_stats, observed_stats, epsilon, model) {
+kernel_fun <- function(simulated_stats, observed_stats, epsilon, lfmcmc_obj) {
   dnorm(sqrt(sum((simulated_stats - observed_stats)^2)))
 }
 ```


### PR DESCRIPTION
This pull request includes several updates to the `LFMCMC` functions and documentation to improve clarity and consistency. 

### Function Parameter Updates:
* Arguments in `fun`s passed to `set_*` now receive the LFMCMC object itself.
* Updated parameter names in `run_lfmcmc`, `set_observed_data`, and other functions to remove trailing underscores for consistency (`R/LFMCMC.R`, `inst/tinytest/test-lfmcmc.R`, `man/LFMCMC.Rd`). [[1]](diffhunk://#diff-7831e522d023edbea0571027e997624dbac7397dd1b9b7c8ad5675b1b42753e0L105-R122) [[2]](diffhunk://#diff-143bf9381e3f00927f451dc6faa1047922bb1afcf59b94f8b82ea1db89e125bcL65-R67) [[3]](diffhunk://#diff-c64236ccce5174dbd0e931a3e61a5e7d7ba6f5cc266e9839aeba2fbdc3792e14L29-R31)

### Documentation Enhancements:
* Added detailed descriptions for function arguments in the `LFMCMC` documentation, specifying the expected input for each parameter (`R/LFMCMC.R`, `man/LFMCMC.Rd`). [[1]](diffhunk://#diff-7831e522d023edbea0571027e997624dbac7397dd1b9b7c8ad5675b1b42753e0R15-R29) [[2]](diffhunk://#diff-c64236ccce5174dbd0e931a3e61a5e7d7ba6f5cc266e9839aeba2fbdc3792e14R152-R161)

### Test Case Modifications:
* Updated test cases to reflect parameter name changes and ensure they align with the new function signatures (`inst/tinytest/test-lfmcmc.R`). [[1]](diffhunk://#diff-143bf9381e3f00927f451dc6faa1047922bb1afcf59b94f8b82ea1db89e125bcL102-R104) [[2]](diffhunk://#diff-143bf9381e3f00927f451dc6faa1047922bb1afcf59b94f8b82ea1db89e125bcL164-R172)

### Minor Fixes:
* Corrected a typo in `.Rbuildignore` to ensure the file is properly ignored (`.Rbuildignore`).

These changes collectively improve the usability and maintainability of the `LFMCMC` functions and their documentation.