### PR TITLE
Fixing Rt values (new version of epiworld) and misc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: epiworldR
 Type: Package
 Title: Fast Agent-Based Epi Models
-Version: 0.8.0.0
+Version: 0.8.1.0
 Depends: R (>= 4.1.0)
 Authors@R: c(
   person(given="George", family="Vega Yon", role=c("aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# epiworldR 0.8.1.0
+
+* Added the `ModelMeaslesQuarantine`.
+
+* Fixes an error in the index case calculation of the Rt function. Getting the Rt was not recovering the index cases with no transmissions.
+
+* Adds the capability of drawing a model diagram using `mermaid`.
+
+* Added an advanced usage vignette.
+
+* Adding input parameter checks (more extensive).
+
+
 # epiworldR 0.6.1.0
 
 * Updates to reflect changes in the `epiworld` C++ library (mostly bug fixes)

--- a/R/ModelMeaslesQuarantine.R
+++ b/R/ModelMeaslesQuarantine.R
@@ -1,4 +1,5 @@
 #' Measles model with quarantine
+#' 
 #' The `ModelMeaslesQuarantine` function implements a connected version
 #' of a Measles model with quarantine.
 #'
@@ -41,6 +42,10 @@
 #' plot(model_measles)
 #'
 #' @seealso epiworld-methods
+#' @author 
+#' This model was built as a response to the US Measles outbreak in 2025. 
+#' This is a collaboration between the University of Utah (ForeSITE center 
+#' grant) and the Utah Department of Health and Human Services.
 ModelMeaslesQuarantine <- function(
     n,
     prevalence = 1,
@@ -103,7 +108,8 @@ ModelMeaslesQuarantine <- function(
 #' @param x Object of class [epiworld_measlesquarantine].
 #' @param main Title of the plot
 #' @param ... Passed to [graphics::plot].
-#' @returns The `plot` function returns a plot of the MeaslesQuarantine model of class
+#' @returns
+#' - The `plot` function returns a plot of the MeaslesQuarantine model of class
 #' [epiworld_model].
 plot.epiworld_measlesquarantine <- function(x, main = get_name(x), ...) { # col = NULL
   plot_epi(x, main = main, ...)

--- a/R/ModelMeaslesQuarantine.R
+++ b/R/ModelMeaslesQuarantine.R
@@ -1,5 +1,5 @@
 #' Measles model with quarantine
-#' 
+#'
 #' The `ModelMeaslesQuarantine` function implements a connected version
 #' of a Measles model with quarantine.
 #'
@@ -42,9 +42,9 @@
 #' plot(model_measles)
 #'
 #' @seealso epiworld-methods
-#' @author 
-#' This model was built as a response to the US Measles outbreak in 2025. 
-#' This is a collaboration between the University of Utah (ForeSITE center 
+#' @author
+#' This model was built as a response to the US Measles outbreak in 2025.
+#' This is a collaboration between the University of Utah (ForeSITE center
 #' grant) and the Utah Department of Health and Human Services.
 ModelMeaslesQuarantine <- function(
     n,

--- a/R/data.R
+++ b/R/data.R
@@ -164,7 +164,7 @@ get_reproductive_number <- function(x) UseMethod("get_reproductive_number")
 #' @export
 get_reproductive_number.epiworld_model <- function(x) {
   res <- get_reproductive_number_cpp(x)
-  res <- res[res[["source"]] != -1]
+  res <- res[res[["source"]] != -1, , drop = FALSE]
   class(res) <- c("epiworld_repnum", class(res))
   res
 }

--- a/R/data.R
+++ b/R/data.R
@@ -164,6 +164,7 @@ get_reproductive_number <- function(x) UseMethod("get_reproductive_number")
 #' @export
 get_reproductive_number.epiworld_model <- function(x) {
   res <- get_reproductive_number_cpp(x)
+  res <- res[res[["source"]] != -1]
   class(res) <- c("epiworld_repnum", class(res))
   res
 }

--- a/inst/include/epiworld/agent-events-meat.hpp
+++ b/inst/include/epiworld/agent-events-meat.hpp
@@ -7,21 +7,13 @@ inline void default_add_virus(Event<TSeq> & a, Model<TSeq> * m)
 
     Agent<TSeq> *  p = a.agent;
     VirusPtr<TSeq> v = a.virus;
-
-    // Has a agent? If so, we need to register the transmission
-    if (v->get_agent())
-    {
-
-        // ... only if not the same agent
-        if (v->get_agent()->get_id() != p->get_id())
-            m->get_db().record_transmission(
-                v->get_agent()->get_id(),
-                p->get_id(),
-                v->get_id(),
-                v->get_date() 
-            );
-
-    }
+    
+    m->get_db().record_transmission(
+        v->get_agent() ? v->get_agent()->get_id() : -1,
+        p->get_id(),
+        v->get_id(),
+        v->get_date() 
+    );
     
     p->virus = std::make_shared< Virus<TSeq> >(*v);
     p->virus->set_date(m->today());

--- a/inst/include/epiworld/database-bones.hpp
+++ b/inst/include/epiworld/database-bones.hpp
@@ -252,6 +252,12 @@ public:
     
     /***
      * @brief Record a transmission event
+     * @param i,j Integers. Id of the source and target agents.
+     * @param virus Integer. Id of the virus.
+     * @param i_expo_date Integer. Date when the source agent was infected.
+     * @details
+     * If i is -1, then it means that the agent was assigned a virus at the
+     * beginning of the simulation.
      */
     void record_transmission(int i, int j, int virus, int i_expo_date);
 
@@ -272,6 +278,11 @@ public:
      * virus is allowed to circulate naïvely or not, respectively.
      * 
      * @param fn File where to write out the reproductive number.
+     * @details
+     * In the case of `MapVec_type<int,int>`, the key is a vector of 3 integers:
+     * - Virus id
+     * - Source id
+     * - Date when the source was infected
      */
     ///@{
     MapVec_type<int,int> reproductive_number() const;

--- a/inst/include/epiworld/epiworld.hpp
+++ b/inst/include/epiworld/epiworld.hpp
@@ -22,7 +22,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 8
-#define EPIWORLD_VERSION_PATCH 0
+#define EPIWORLD_VERSION_PATCH 1
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;

--- a/man/ModelMeaslesQuarantine.Rd
+++ b/man/ModelMeaslesQuarantine.Rd
@@ -4,9 +4,7 @@
 \alias{ModelMeaslesQuarantine}
 \alias{epiworld_measlesquarantine}
 \alias{plot.epiworld_measlesquarantine}
-\title{Measles model with quarantine
-The \code{ModelMeaslesQuarantine} function implements a connected version
-of a Measles model with quarantine.}
+\title{Measles model with quarantine}
 \usage{
 ModelMeaslesQuarantine(
   n,
@@ -70,11 +68,12 @@ ModelMeaslesQuarantine(
 \item The \code{ModelMeaslesQuarantine} function returns a model of class \link{epiworld_model}.
 }
 
-The \code{plot} function returns a plot of the MeaslesQuarantine model of class
+\itemize{
+\item The \code{plot} function returns a plot of the MeaslesQuarantine model of class
 \link{epiworld_model}.
 }
+}
 \description{
-Measles model with quarantine
 The \code{ModelMeaslesQuarantine} function implements a connected version
 of a Measles model with quarantine.
 }
@@ -118,5 +117,10 @@ Other Models:
 \code{\link{ModelSISD}()},
 \code{\link{ModelSURV}()},
 \code{\link{epiworld-data}}
+}
+\author{
+This model was built as a response to the US Measles outbreak in 2025.
+This is a collaboration between the University of Utah (ForeSITE center
+grant) and the Utah Department of Health and Human Services.
 }
 \concept{Models}


### PR DESCRIPTION
This pull request introduces a version update for `epiworldR` (from 0.8.0.0 to 0.8.1.0) and includes several enhancements, bug fixes, and documentation updates. Key changes include adding a new model (`ModelMeaslesQuarantine`), improving the calculation of the reproductive number (Rt), and extending functionality for model visualization and parameter validation.

### Version Update and Documentation:

* Updated the package version to `0.8.1.0` in `DESCRIPTION` and `epiworld` versioning macros. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL4-R4) [[2]](diffhunk://#diff-429e788e369e6d86361df82a6f2b1f6df1dae069c6b9d7ac7186ddd11069cd5fL25-R25)
* Added a changelog entry in `NEWS.md` summarizing new features, fixes, and enhancements, including the addition of `ModelMeaslesQuarantine`, an advanced usage vignette, and parameter checks.

### Bug Fixes:

* Fixed an issue in the `get_reproductive_number.epiworld_model` function reflecting recent changes in the main library.
* Updated the `record_transmission` logic to handle cases where the source agent is not defined (e.g., initial infections) by assigning a default value of `-1`.

### Enhancements:

* Added support for drawing model diagrams using `mermaid`.
* Improved `record_transmission` and `reproductive_number` documentation to clarify parameter details and edge cases. [[1]](diffhunk://#diff-db2169fb3eb20d895b59d237371bf8e466b0337f656bca9afe1b6315c8350d78R255-R260) [[2]](diffhunk://#diff-db2169fb3eb20d895b59d237371bf8e466b0337f656bca9afe1b6315c8350d78R281-R285)