### PR TITLE
bubbles(): replicates no longer have to run on one thread

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,8 @@
   bubbles are is held in a model parameter (`"Bubble transmission factor"` by
   default), which scales transmission along out-of-bubble contacts and can be
   read with `get_param()` and changed with `set_param()` at any point.
-  `sample_household_sizes()` draws household sizes to go with it.
+  Each copy of a model keeps its own bubbles, so replicates run on any number
+  of threads. `sample_household_sizes()` draws household sizes to go with it.
 
 * New vignette, "Using external network data: GeoPops synthetic populations",
   showing how to bring an externally-generated population and its contact

--- a/R/bubbles.R
+++ b/R/bubbles.R
@@ -140,9 +140,11 @@
 #'
 #' The bubbles are drawn afresh at the start of every run, using that run's seed,
 #' and are already in force on day 1. With `rewire_every > 0` they are redrawn
-#' during the run, taking effect the following day. Because the intervention
-#' keeps a single shared state, replicates with [run_multiple] must use one
-#' thread (`nthreads = 1`); `bubbles()` flags the model accordingly.
+#' during the run, taking effect the following day.
+#'
+#' The partition belongs to the model rather than to the intervention, so each
+#' of the per-thread copies of the model that [run_multiple()] makes draws and
+#' keeps its own. Replicates may run on as many threads as you like.
 #'
 #' ## What this cannot represent
 #'
@@ -288,10 +290,6 @@ bubbles <- function(
     max_households,
     param_name
   )
-
-  # A single shared state backs the intervention, so parallel replicates must
-  # run single-threaded.
-  attr(model, "single_threaded") <- TRUE
 
   invisible(model)
 

--- a/inst/include/epiworld/epiworld.hpp
+++ b/inst/include/epiworld/epiworld.hpp
@@ -127,7 +127,7 @@ namespace epiworld {
     #include "tools/vaccine.hpp"
     #include "globalevents/quarantinetrigger-meat.hpp"
     #include "globalevents/bubbles-meat.hpp"
-    
+
     #include "models/models.hpp"
 
 }

--- a/inst/include/epiworld/globalevent-bones.hpp
+++ b/inst/include/epiworld/globalevent-bones.hpp
@@ -34,6 +34,19 @@ public:
 
     virtual void operator()(Model<TSeq> * m, int day);
 
+    /**
+     * @brief Prepare the event for a run.
+     *
+     * @details Called by `Model::reset()` at the end of every reset, i.e. once
+     * per run and once per replicate of `Model::run_multiple()`, with the run's
+     * RNG already seeded and the agents, tools, and viruses distributed. Events
+     * that need to set themselves up on the model they are running in -- the
+     * moment before day 1 -- do it here; the default does nothing.
+     *
+     * @param m The model the event belongs to.
+     */
+    virtual void reset(Model<TSeq> * m);
+
     void set_name(std::string name);
     std::string get_name() const;
 

--- a/inst/include/epiworld/globalevent-meat.hpp
+++ b/inst/include/epiworld/globalevent-meat.hpp
@@ -32,6 +32,12 @@ inline void GlobalEvent<TSeq>::operator()(Model<TSeq> * m, int day)
 }
 
 template<typename TSeq>
+inline void GlobalEvent<TSeq>::reset(Model<TSeq> *)
+{
+    return;
+}
+
+template<typename TSeq>
 inline void GlobalEvent<TSeq>::set_name(std::string name)
 {
     this->name = name;

--- a/inst/include/epiworld/globalevents/bubbles-bones.hpp
+++ b/inst/include/epiworld/globalevents/bubbles-bones.hpp
@@ -45,20 +45,51 @@ enum class BubbleFlavor {
     Peer
 };
 
+template<typename TSeq>
+class Bubbles;
+
 /**
- * @brief Shared, mutable state of a Bubbles intervention.
+ * @brief Tool carried by every agent under a Bubbles policy.
+ * @ingroup globalevents
  *
- * Held via `std::shared_ptr` and captured by both the bubble `Tool`
- * (read-only) and the scheduler `GlobalEvent` (read-write), so the two stay in
- * sync for the lifetime of the model. The bubble partition is a per-agent
- * integer label (`bubble_id`): agents whose labels match are in the same bubble
- * and transmit freely, while transmission between different labels is scaled
- * down by the intervention's transmission factor.
+ * @details The tool does not hold the bubble partition -- it holds a pointer to
+ * the `Bubbles` intervention that owns it, resolved by name from the model the
+ * first time the tool is used. `clone_ptr()` clears that pointer, exactly as
+ * `ToolVaccine` clears its per-agent immunity, so a copy of the tool always
+ * re-resolves against the model it ends up in. Copies of a model therefore
+ * never reach into the model they were copied from, which is what lets bubble
+ * models run in parallel replicates.
+ *
+ * Users do not instantiate this directly; `Bubbles::deploy()` does.
+ *
+ * @tparam TSeq Sequence type (should match `TSeq` across the model).
  */
-struct BubbleState {
-    std::vector< int > bubble_id;  ///< Per-agent bubble label (index = agent id); -1 = unassigned.
-    int last_sim_id = -1;          ///< Sim id the current partition was computed for.
-    int last_epoch  = -1;          ///< Rewiring epoch the current partition was computed for.
+template<typename TSeq = EPI_DEFAULT_TSEQ>
+class BubbleTool : public Tool<TSeq> {
+private:
+
+    std::string _event_name;                  ///< Name of the owning intervention.
+    Bubbles<TSeq> * _policy = nullptr;        ///< Resolved lazily, per model.
+
+public:
+
+    BubbleTool(std::string name, std::string event_name);
+
+    /**
+     * @brief Reduction applied to an exposure of this tool's agent.
+     *
+     * `0.0` when the transmitter shares the agent's bubble (contacts inside the
+     * bubble are what the policy preserves), and `1 - f` otherwise, where `f`
+     * is the intervention's transmission factor. Outside the policy window, or
+     * before a partition exists, the reduction is `0.0`.
+     */
+    epiworld_double get_susceptibility_reduction(
+        VirusPtr<TSeq> & v,
+        Model<TSeq> * model
+    ) override;
+
+    std::unique_ptr<Tool<TSeq>> clone_ptr() const override;
+
 };
 
 /**
@@ -74,10 +105,10 @@ struct BubbleState {
  * ## How it works
  *
  * The contact network is **not modified**. Instead, `deploy()` attaches a
- * `Tool` ("Social bubble") to every agent. When a susceptible agent `p` is
- * exposed to an infectious neighbor, the tool's susceptibility-reduction
- * function identifies the transmitter through the virus (`v->get_agent()`) and
- * compares the two agents' bubble labels:
+ * `BubbleTool` ("Social bubble") to every agent. When a susceptible agent `p`
+ * is exposed to an infectious neighbor, the tool identifies the transmitter
+ * through the virus (`v->get_agent()`) and compares the two agents' bubble
+ * labels:
  *
  * - same bubble  -> reduction `0.0`: contacts *inside* the bubble are what the
  *                   policy preserves, so they are left untouched;
@@ -106,6 +137,24 @@ struct BubbleState {
  * suppressing transmission on out-of-bubble contacts is equivalent to deleting
  * those contacts, while keeping the network intact for other purposes (contact
  * tracing, output).
+ *
+ * ## Where the state lives
+ *
+ * `Bubbles` *is* the model's global event: `deploy()` hands the model a clone
+ * of it, and the bubble partition (`get_bubble_id()`) is a member of that
+ * clone. Since `Model`'s copy constructor deep-copies global events and tools,
+ * every copy of a model -- including the per-thread copies `run_multiple()`
+ * makes -- owns its partition outright, and the tool resolves to the
+ * intervention of whichever model it belongs to. Nothing is shared between
+ * models, so replicates may run on as many threads as you like.
+ *
+ * The object you construct is a template: after `deploy()` it is no longer
+ * connected to the model, and its own `get_bubble_id()` stays empty. To look at
+ * the partition of a model that has run, ask the model for its copy:
+ *
+ * ```cpp
+ * const auto & bubble_id = Bubbles<>::get_from(model)->get_bubble_id();
+ * ```
  *
  * ## Forming bubbles (why ties matter)
  *
@@ -195,7 +244,8 @@ struct BubbleState {
  * The initial partition is computed at reset time via the tool's distribution
  * function, so it is recomputed for each replicate of `run_multiple()` using
  * that replicate's seed and is already in force on day 1. Re-randomisations are
- * applied by a daily global event and take effect the following step.
+ * applied by the intervention itself (a daily global event) and take effect the
+ * following step.
  *
  * ## Example
  *
@@ -221,10 +271,10 @@ struct BubbleState {
  * model.set_param("Bubble transmission factor", 0.25);
  *
  * model.run(100, 1231);
- * ```
  *
- * @note All copies of a `Bubbles` object share one `BubbleState`, so replicates
- * in `run_multiple()` must run on a single thread (`nthreads = 1`).
+ * // The partition belongs to the model, not to `bubbles`.
+ * const auto & bubble_id = Bubbles<>::get_from(model)->get_bubble_id();
+ * ```
  *
  * @note Both rules produce *exclusive* bubbles, which is what the modelled
  * policies prescribe. A rule that instead grants each person a personal budget
@@ -239,7 +289,7 @@ struct BubbleState {
  * @tparam TSeq Sequence type (should match `TSeq` across the model).
  */
 template<typename TSeq = EPI_DEFAULT_TSEQ>
-class Bubbles {
+class Bubbles final : public GlobalEvent<TSeq> {
 private:
 
     std::vector< size_t > household_id;
@@ -250,13 +300,16 @@ private:
     int start_day;
     int end_day;
     int rewire_every;
-    std::string name;
     std::string param_name;          ///< model parameter holding the transmission factor.
-    std::shared_ptr< BubbleState > state;
 
-    void compute_partition(Model<TSeq> * model) const;
-    void partition_household(Model<TSeq> * model) const;
-    void partition_peer(Model<TSeq> * model) const;
+    // Per-model state. Copied with the intervention, so each model (including
+    // each per-thread copy made by run_multiple) owns its own partition.
+    std::vector< int > bubble_id;    ///< Per-agent bubble label; -1 = unassigned.
+    int last_sim_id = -1;            ///< Sim id the current partition was computed for.
+    int last_epoch  = -1;            ///< Rewiring epoch the current partition was computed for.
+
+    void partition_household(Model<TSeq> * model);
+    void partition_peer(Model<TSeq> * model);
 
 public:
 
@@ -288,8 +341,9 @@ public:
      * @param rewire_every Re-randomise the bubbles every this-many days, for
      *        policies whose contacts change over time. `0` keeps the bubbles
      *        fixed for the whole intervention.
-     * @param name Name given to the tool and to the scheduler event; useful to
-     *        look them up on the model afterwards.
+     * @param name Name given to the tool and to the intervention's global
+     *        event; the tool finds its policy by this name, and `get_from()`
+     *        looks it up on a model with it.
      * @param max_households **`Peer` flavor only**: the largest number of
      *        households a bubble may contain. A nomination that would exceed it
      *        is declined, which is what stops one household's choices from
@@ -323,9 +377,9 @@ public:
      *
      * Registers the model parameter `param_name` (set to the
      * `transmission_factor` passed to the constructor, overwriting any value it
-     * already had), adds the bubble `Tool` (distributed to every agent, which
-     * also computes the bubble partition at each reset) and, when
-     * `rewire_every > 0`, the global event that re-randomises the bubbles.
+     * already had), hands the model a copy of this intervention as a global
+     * event, and adds the bubble `Tool`, which is given to every agent at reset
+     * time -- the same moment the partition is computed.
      *
      * To drive the factor from a parameter file instead, call
      * `model.read_params()` (or `set_param()`) *after* `deploy()`.
@@ -341,18 +395,33 @@ public:
     void deploy(Model<TSeq> & model);
 
     /**
-     * @brief Shared state of the intervention (bubble labels and bookkeeping).
+     * @brief The model's copy of a deployed intervention.
      *
-     * The state is shared by every copy of this object and by the model's tool
-     * and event, and is refreshed on each run.
+     * @param model Model the intervention was deployed on.
+     * @param name Name it was deployed under.
+     * @return Pointer to the model's own intervention, or `nullptr` if the
+     *         model has no global event by that name, or it is not a `Bubbles`.
      */
-    std::shared_ptr< BubbleState > get_state() const;
+    static Bubbles<TSeq> * get_from(
+        Model<TSeq> & model,
+        const std::string & name = "Social bubble"
+    );
+
+    /**
+     * @brief Recompute the partition using the model's RNG.
+     *
+     * Called at reset time (through the tool's distribution function) and at
+     * each rewiring epoch. Rarely needed directly.
+     */
+    void compute_partition(Model<TSeq> * model);
 
     /**
      * @brief Current bubble label of every agent, indexed by agent id.
      *
-     * Two agents may transmit only when their labels are equal. Populated on the
-     * first reset (i.e. once the model has been run); empty before then.
+     * Two agents in the same bubble transmit as they would without the policy;
+     * transmission between labels is scaled by the transmission factor.
+     * Populated on the first reset, and only on the model's own copy of the
+     * intervention -- see `get_from()`.
      */
     const std::vector< int > & get_bubble_id() const;
 
@@ -366,6 +435,33 @@ public:
      * how leaky the bubbles are, including in the middle of a run.
      */
     const std::string & get_param_name() const;
+
+    /// @brief True when the policy applies on the given day.
+    bool is_active(int today) const;
+
+    /**
+     * @brief Rewiring epoch the current partition was computed for.
+     *
+     * `0` for the partition drawn at reset, incrementing every `rewire_every`
+     * days while the policy is active. `-1` before the first partition.
+     */
+    int get_last_epoch() const;
+
+    /**
+     * @brief Reduction applied to an exposure between two agents.
+     *
+     * The tool's side of the intervention; see `BubbleTool`.
+     */
+    epiworld_double susceptibility_reduction(
+        const Agent<TSeq> * p,
+        const Agent<TSeq> * transmitter,
+        Model<TSeq> * model
+    ) const;
+
+    /// @brief Re-randomises the partition at rewiring epochs.
+    void operator()(Model<TSeq> * model, int day) override;
+
+    std::unique_ptr< GlobalEvent<TSeq> > clone_ptr() const override;
 
 };
 

--- a/inst/include/epiworld/globalevents/bubbles-bones.hpp
+++ b/inst/include/epiworld/globalevents/bubbles-bones.hpp
@@ -60,7 +60,8 @@ class Bubbles;
  * never reach into the model they were copied from, which is what lets bubble
  * models run in parallel replicates.
  *
- * Users do not instantiate this directly; `Bubbles::deploy()` does.
+ * Users do not instantiate this directly; the intervention hands it to every
+ * agent when it sets itself up, at the start of each run.
  *
  * @tparam TSeq Sequence type (should match `TSeq` across the model).
  */
@@ -104,9 +105,22 @@ public:
  *
  * ## How it works
  *
- * The contact network is **not modified**. Instead, `deploy()` attaches a
- * `BubbleTool` ("Social bubble") to every agent. When a susceptible agent `p`
- * is exposed to an infectious neighbor, the tool identifies the transmitter
+ * The intervention is a global event, so installing it is a one-liner:
+ *
+ * ```cpp
+ * model.add_globalevent(bubbles);
+ * ```
+ *
+ * Everything else happens by itself. At the start of every run -- from
+ * `Model::reset()`, so the policy is in force on day 1 -- the intervention sets
+ * itself up on the model it is running in: it registers the
+ * transmission-factor parameter, draws the bubble partition with that run's
+ * RNG, and hands a `BubbleTool` ("Social bubble") to every agent. Each
+ * replicate of `run_multiple()` -- each of which runs on its own copy of the
+ * model, possibly on its own thread -- repeats this with its own seed.
+ *
+ * The contact network is **not modified**. When a susceptible agent `p` is
+ * exposed to an infectious neighbor, the tool identifies the transmitter
  * through the virus (`v->get_agent()`) and compares the two agents' bubble
  * labels:
  *
@@ -124,12 +138,15 @@ public:
  * values model a soft contact reduction -- people still meet outside their
  * bubble, just less often or more carefully.
  *
- * `f` is **not** stored in the intervention: `deploy()` registers it as a model
+ * `f` is **not** stored in the intervention: setup registers it as a model
  * parameter (`param_name`, "Bubble transmission factor" by default) and the
  * tool reads it from the model on every exposure. It can therefore be inspected
- * with `model.get_param()`, changed mid-run with `model.set_param()`, read from
- * a parameter file with `model.read_params()`, or swept over in a calibration
- * without rebuilding the intervention. Values outside `[0, 1]` are clamped.
+ * with `model.get_param()`, changed mid-run with `model.set_param()`, or swept
+ * over in a calibration without rebuilding the intervention. The value given to
+ * the constructor is only a default: if the model already carries that
+ * parameter -- because it was set with `model.add_param()` or read from a
+ * parameter file with `model.read_params()` before the run -- the model's value
+ * is kept. Values outside `[0, 1]` are clamped.
  *
  * Since reductions combine as `1 - prod(1 - r_i)`, a reduction of `1.0`
  * (`f == 0`) zeroes the transmission probability regardless of any other tools
@@ -140,17 +157,17 @@ public:
  *
  * ## Where the state lives
  *
- * `Bubbles` *is* the model's global event: `deploy()` hands the model a clone
- * of it, and the bubble partition (`get_bubble_id()`) is a member of that
+ * `Bubbles` *is* the model's global event: `add_globalevent()` hands the model a
+ * clone of it, and the bubble partition (`get_bubble_id()`) is a member of that
  * clone. Since `Model`'s copy constructor deep-copies global events and tools,
  * every copy of a model -- including the per-thread copies `run_multiple()`
  * makes -- owns its partition outright, and the tool resolves to the
  * intervention of whichever model it belongs to. Nothing is shared between
  * models, so replicates may run on as many threads as you like.
  *
- * The object you construct is a template: after `deploy()` it is no longer
- * connected to the model, and its own `get_bubble_id()` stays empty. To look at
- * the partition of a model that has run, ask the model for its copy:
+ * The object you construct is a template: once added to a model it is no longer
+ * connected to it, and its own `get_bubble_id()` stays empty. To look at the
+ * partition of a model that has run, ask the model for its copy:
  *
  * ```cpp
  * const auto & bubble_id = Bubbles<>::get_from(model)->get_bubble_id();
@@ -241,11 +258,11 @@ public:
  * re-randomised every that-many days, modelling policies whose bubbles change
  * over time (e.g. contacts renewed weekly); `0` keeps a fixed bubble.
  *
- * The initial partition is computed at reset time via the tool's distribution
- * function, so it is recomputed for each replicate of `run_multiple()` using
- * that replicate's seed and is already in force on day 1. Re-randomisations are
- * applied by the intervention itself (a daily global event) and take effect the
- * following step.
+ * The initial partition is drawn when the intervention sets itself up, at reset
+ * time, so it is redrawn for each replicate of `run_multiple()` using that
+ * replicate's seed and is already in force on day 1. Re-randomisations are
+ * applied by the intervention itself (a daily global event) and, since global
+ * events run after each day's transitions, take effect the following step.
  *
  * ## Example
  *
@@ -261,14 +278,14 @@ public:
  * Bubbles<> bubbles(
  *     household_id, BubbleFlavor::Household,
  *     2,      // group_size
- *     0.5,    // transmission_factor (initial value of the model parameter)
+ *     0.5,    // transmission_factor (default of the model parameter)
  *     10      // start_day
  * );
- * bubbles.deploy(model);
+ * model.add_globalevent(bubbles);
  *
- * // The factor lives in the model, so it can be changed without touching
- * // the intervention.
- * model.set_param("Bubble transmission factor", 0.25);
+ * // The factor lives in the model, so it can be changed without touching the
+ * // intervention. Setting it before the run overrides the default above.
+ * model.add_param(0.25, "Bubble transmission factor", true);
  *
  * model.run(100, 1231);
  *
@@ -305,11 +322,25 @@ private:
     // Per-model state. Copied with the intervention, so each model (including
     // each per-thread copy made by run_multiple) owns its own partition.
     std::vector< int > bubble_id;    ///< Per-agent bubble label; -1 = unassigned.
-    int last_sim_id = -1;            ///< Sim id the current partition was computed for.
-    int last_epoch  = -1;            ///< Rewiring epoch the current partition was computed for.
+    int model_id   = -1;             ///< Sim id this intervention was set up for.
+    int last_epoch = -1;             ///< Rewiring epoch the current partition was computed for.
 
     void partition_household(Model<TSeq> * model);
     void partition_peer(Model<TSeq> * model);
+
+    /**
+     * @brief Install the intervention on the model it is running in.
+     *
+     * @details Called from `reset()`, i.e. once per run and once per replicate
+     * of `run_multiple()`. It registers the transmission-factor parameter
+     * (keeping any value the model already has), draws the epoch-0 partition
+     * with the run's RNG, and gives the bubble tool to every agent.
+     *
+     * @param model Model the intervention belongs to.
+     * @throws std::length_error if `household_id` does not have exactly one
+     *         entry per agent.
+     */
+    void _setup(Model<TSeq> * model);
 
 public:
 
@@ -373,32 +404,10 @@ public:
     );
 
     /**
-     * @brief Install the intervention on a model.
+     * @brief The model's copy of the intervention.
      *
-     * Registers the model parameter `param_name` (set to the
-     * `transmission_factor` passed to the constructor, overwriting any value it
-     * already had), hands the model a copy of this intervention as a global
-     * event, and adds the bubble `Tool`, which is given to every agent at reset
-     * time -- the same moment the partition is computed.
-     *
-     * To drive the factor from a parameter file instead, call
-     * `model.read_params()` (or `set_param()`) *after* `deploy()`.
-     *
-     * Call this **after** the model's agents and contact network exist (e.g.
-     * after `agents_smallworld()`), since the household grouping is derived from
-     * the network, and before `run()`.
-     *
-     * @param model Model to install the intervention on.
-     * @throws std::length_error if `household_id` does not have exactly one
-     *         entry per agent.
-     */
-    void deploy(Model<TSeq> & model);
-
-    /**
-     * @brief The model's copy of a deployed intervention.
-     *
-     * @param model Model the intervention was deployed on.
-     * @param name Name it was deployed under.
+     * @param model Model the intervention was added to.
+     * @param name Name it was added under.
      * @return Pointer to the model's own intervention, or `nullptr` if the
      *         model has no global event by that name, or it is not a `Bubbles`.
      */
@@ -410,8 +419,8 @@ public:
     /**
      * @brief Recompute the partition using the model's RNG.
      *
-     * Called at reset time (through the tool's distribution function) and at
-     * each rewiring epoch. Rarely needed directly.
+     * Called when the intervention sets itself up (at reset) and at each
+     * rewiring epoch. Rarely needed directly.
      */
     void compute_partition(Model<TSeq> * model);
 
@@ -420,8 +429,8 @@ public:
      *
      * Two agents in the same bubble transmit as they would without the policy;
      * transmission between labels is scaled by the transmission factor.
-     * Populated on the first reset, and only on the model's own copy of the
-     * intervention -- see `get_from()`.
+     * Populated at the start of each run, and only on the model's own copy of
+     * the intervention -- see `get_from()`.
      */
     const std::vector< int > & get_bubble_id() const;
 
@@ -442,7 +451,7 @@ public:
     /**
      * @brief Rewiring epoch the current partition was computed for.
      *
-     * `0` for the partition drawn at reset, incrementing every `rewire_every`
+     * `0` for the partition drawn at setup, incrementing every `rewire_every`
      * days while the policy is active. `-1` before the first partition.
      */
     int get_last_epoch() const;
@@ -457,6 +466,14 @@ public:
         const Agent<TSeq> * transmitter,
         Model<TSeq> * model
     ) const;
+
+    /**
+     * @brief Installs the intervention on the model, once per run.
+     *
+     * Called by `Model::reset()`; see `_setup()`. This is what makes adding the
+     * intervention to a model the only step there is.
+     */
+    void reset(Model<TSeq> * model) override;
 
     /// @brief Re-randomises the partition at rewiring epochs.
     void operator()(Model<TSeq> * model, int day) override;

--- a/inst/include/epiworld/globalevents/bubbles-meat.hpp
+++ b/inst/include/epiworld/globalevents/bubbles-meat.hpp
@@ -408,91 +408,96 @@ inline epiworld_double Bubbles<TSeq>::susceptibility_reduction(
 }
 
 template<typename TSeq>
+inline void Bubbles<TSeq>::_setup(Model<TSeq> * model)
+{
+
+    if (household_id.size() != model->size())
+        throw std::length_error(
+            "Bubbles: household_id length (" +
+            std::to_string(household_id.size()) +
+            ") must equal the number of agents (" +
+            std::to_string(model->size()) + ")."
+        );
+
+    // ---- The transmission factor lives in the model -------------------------
+    // The tool reads it on every exposure rather than holding a copy, so the
+    // strictness of the policy can be inspected, calibrated, or switched
+    // mid-run through the model's parameters. The value passed to the
+    // constructor is only a default: a value already in the model (set by the
+    // user, or read from a parameter file) is what governs the run.
+    if (!model->has_param(param_name))
+        model->add_param(transmission_factor, param_name);
+
+    // ---- The partition ------------------------------------------------------
+    // Drawn with the model's RNG, which the run has already seeded, so each
+    // replicate of run_multiple() gets its own partition from its own seed and
+    // never inherits one from a previous run.
+    compute_partition(model);
+    last_epoch = 0;
+
+    // ---- The tool: dampens out-of-bubble transmission -----------------------
+    // It carries no state of its own: it finds the model's intervention by name
+    // the first time it is used. It is registered without a distribution
+    // function on purpose -- handing it out here, on every run, keeps the first
+    // run and the ones after it (where the tool is already registered)
+    // identical.
+    if (!model->has_tool(this->get_name()))
+    {
+        BubbleTool<TSeq> bubble_tool(this->get_name(), this->get_name());
+        model->add_tool(bubble_tool);
+    }
+
+    auto & bubble_tool = model->get_tool(this->get_name());
+    for (size_t i = 0u; i < model->size(); ++i)
+        model->get_agent(i).add_tool(*model, bubble_tool);
+
+}
+
+template<typename TSeq>
+inline void Bubbles<TSeq>::reset(Model<TSeq> * model)
+{
+
+    // Model::reset() runs this once per run -- and once per replicate of
+    // run_multiple(), on that replicate's own copy of the model -- just before
+    // day 1, which is why the user has nothing to call: adding the intervention
+    // to the model is the whole installation.
+    this->model_id = static_cast< int >(model->get_sim_id());
+    this->_setup(model);
+
+}
+
+template<typename TSeq>
 inline void Bubbles<TSeq>::operator()(Model<TSeq> * model, int day)
 {
 
-    // Only rewiring needs a daily event; the tool gates itself by day, and the
-    // epoch-0 partition is computed at reset (see deploy()). Because global
-    // events run after update_state(), a rewired partition takes effect the
-    // following simulation step.
+    // Under Model::run() this never fires: reset() has already set us up for
+    // this run. It is here for a model whose day loop is driven by hand, where
+    // installing the policy a day late still beats running without it. The
+    // simulation id is what tells one run from the next, so a copy of the model
+    // (another replicate, another thread) sets itself up on its own.
+    if (static_cast< int >(model->get_sim_id()) != this->model_id)
+    {
+        this->model_id = static_cast< int >(model->get_sim_id());
+        this->_setup(model);
+    }
+
+    // Past setup, the only thing left for the daily event is rewiring; the tool
+    // gates itself by day. Because global events run after update_state(), a
+    // rewired partition takes effect the following simulation step.
     if (rewire_every <= 0)
         return;
 
     if (!is_active(day))
         return;
 
-    int sim   = static_cast< int >(model->get_sim_id());
     int epoch = (day - start_day) / rewire_every;
 
-    // Already up to date for this (replicate, epoch).
-    if ((last_sim_id == sim) && (last_epoch == epoch))
+    // Already up to date for this epoch.
+    if (last_epoch == epoch)
         return;
 
     compute_partition(model);
-    last_sim_id = sim;
-    last_epoch  = epoch;
-
-}
-
-template<typename TSeq>
-inline void Bubbles<TSeq>::deploy(Model<TSeq> & model)
-{
-
-    if (household_id.size() != model.size())
-        throw std::length_error(
-            "Bubbles: household_id length (" +
-            std::to_string(household_id.size()) +
-            ") must equal the number of agents (" +
-            std::to_string(model.size()) + ")."
-        );
-
-    // ---- The transmission factor lives in the model -------------------------
-    // The tool reads it on every exposure rather than holding a copy, so the
-    // strictness of the policy can be inspected, calibrated, or switched
-    // mid-run through the model's parameters.
-    model.add_param(transmission_factor, param_name, true);
-
-    // ---- The intervention itself -------------------------------------------
-    // add_globalevent() clones this object, so the model owns the partition and
-    // the rewiring schedule. Copies of the model (e.g. the per-thread copies
-    // made by run_multiple) clone it again and are fully independent.
-    model.add_globalevent(*this);
-
-    // ---- The tool: dampens out-of-bubble transmission -----------------------
-    // It carries no state of its own: it finds the model's intervention by name
-    // the first time it is used.
-    BubbleTool<TSeq> bubble_tool(this->get_name(), this->get_name());
-
-    // ---- Distribution: recompute the partition at reset time ----------------
-    // The tool's distribution function runs from Model::reset() -> dist_tools(),
-    // i.e. *before* day 1 and with the run's (per-replicate) RNG already seeded.
-    // Computing the partition here — rather than eagerly in deploy() — keeps the
-    // epoch-0 partition fresh for every replicate of run_multiple() and avoids
-    // any dependence on a stale partition left over from a previous run. It then
-    // distributes the tool to every agent (prevalence 1.0).
-    std::string ename = this->get_name();
-    ToolToAgentFun<TSeq> distribute_all = distribute_tool_randomly<TSeq>(1.0, true);
-    bubble_tool.set_distribution(
-        [ename, distribute_all](Tool<TSeq> & tool, Model<TSeq> * m) -> void {
-
-            Bubbles<TSeq> * self = Bubbles<TSeq>::get_from(*m, ename);
-
-            if (self == nullptr)
-                throw std::logic_error(
-                    "Bubbles: the intervention '" + ename +
-                    "' is not installed on this model."
-                );
-
-            self->compute_partition(m);
-            self->last_sim_id = static_cast< int >(m->get_sim_id());
-            self->last_epoch  = 0;
-
-            distribute_all(tool, m);
-
-        }
-    );
-
-    model.add_tool(bubble_tool);
+    last_epoch = epoch;
 
 }
 

--- a/inst/include/epiworld/globalevents/bubbles-meat.hpp
+++ b/inst/include/epiworld/globalevents/bubbles-meat.hpp
@@ -7,6 +7,51 @@
 #include "bubbles-bones.hpp"
 
 template<typename TSeq>
+inline BubbleTool<TSeq>::BubbleTool(
+    std::string name,
+    std::string event_name
+) : Tool<TSeq>(name), _event_name(std::move(event_name))
+{
+}
+
+template<typename TSeq>
+inline epiworld_double BubbleTool<TSeq>::get_susceptibility_reduction(
+    VirusPtr<TSeq> & v,
+    Model<TSeq> * model
+)
+{
+
+    // Binding to the policy of *this* model, once. clone_ptr() clears the
+    // pointer, so a copy of this tool -- in another agent, or in a copy of the
+    // model -- resolves against its own model rather than inheriting ours.
+    if (_policy == nullptr)
+    {
+
+        _policy = Bubbles<TSeq>::get_from(*model, _event_name);
+
+        if (_policy == nullptr)
+            throw std::logic_error(
+                "BubbleTool: the intervention '" + _event_name +
+                "' is not installed on this model."
+            );
+
+    }
+
+    return _policy->susceptibility_reduction(
+        this->get_agent(), v->get_agent(), model
+    );
+
+}
+
+template<typename TSeq>
+inline std::unique_ptr<Tool<TSeq>> BubbleTool<TSeq>::clone_ptr() const
+{
+    auto ans = std::make_unique<BubbleTool<TSeq>>(*this);
+    ans->_policy = nullptr; // the copy resolves against its own model
+    return ans;
+}
+
+template<typename TSeq>
 inline Bubbles<TSeq>::Bubbles(
     std::vector< size_t > household_id,
     BubbleFlavor flavor,
@@ -27,10 +72,11 @@ inline Bubbles<TSeq>::Bubbles(
     start_day(start_day),
     end_day(end_day),
     rewire_every(rewire_every),
-    name(std::move(name)),
-    param_name(std::move(param_name)),
-    state(std::make_shared< BubbleState >())
+    param_name(std::move(param_name))
 {
+
+    this->set_name(name);
+    this->set_day(-99); // runs at the end of every day
 
     if ((this->transmission_factor < 0.0) || (this->transmission_factor > 1.0))
         throw std::range_error(
@@ -55,7 +101,7 @@ inline Bubbles<TSeq>::Bubbles(
 }
 
 template<typename TSeq>
-inline void Bubbles<TSeq>::partition_household(Model<TSeq> * model) const
+inline void Bubbles<TSeq>::partition_household(Model<TSeq> * model)
 {
 
     // Map household label -> compact index, and list unique households.
@@ -169,12 +215,12 @@ inline void Bubbles<TSeq>::partition_household(Model<TSeq> * model) const
 
     // Assign each agent the bubble of its household.
     for (size_t a = 0u; a < household_id.size(); ++a)
-        state->bubble_id[a] = hh_bubble[hh_index[household_id[a]]];
+        bubble_id[a] = hh_bubble[hh_index[household_id[a]]];
 
 }
 
 template<typename TSeq>
-inline void Bubbles<TSeq>::partition_peer(Model<TSeq> * model) const
+inline void Bubbles<TSeq>::partition_peer(Model<TSeq> * model)
 {
 
     size_t n = household_id.size();
@@ -293,27 +339,98 @@ inline void Bubbles<TSeq>::partition_peer(Model<TSeq> * model) const
         if (it == root_label.end())
         {
             root_label[root] = next_label;
-            state->bubble_id[a] = next_label;
+            bubble_id[a] = next_label;
             ++next_label;
         }
         else
         {
-            state->bubble_id[a] = it->second;
+            bubble_id[a] = it->second;
         }
     }
 
 }
 
 template<typename TSeq>
-inline void Bubbles<TSeq>::compute_partition(Model<TSeq> * model) const
+inline void Bubbles<TSeq>::compute_partition(Model<TSeq> * model)
 {
 
-    state->bubble_id.assign(household_id.size(), -1);
+    bubble_id.assign(household_id.size(), -1);
 
     if (flavor == BubbleFlavor::Household)
         partition_household(model);
     else
         partition_peer(model);
+
+}
+
+template<typename TSeq>
+inline bool Bubbles<TSeq>::is_active(int today) const
+{
+    return (today >= start_day) && ((end_day < 0) || (today < end_day));
+}
+
+template<typename TSeq>
+inline epiworld_double Bubbles<TSeq>::susceptibility_reduction(
+    const Agent<TSeq> * p,
+    const Agent<TSeq> * transmitter,
+    Model<TSeq> * model
+) const
+{
+
+    if (!is_active(static_cast< int >(model->today())))
+        return 0.0;
+
+    if (bubble_id.empty() || (p == nullptr) || (transmitter == nullptr))
+        return 0.0;
+
+    int bp = bubble_id[static_cast< size_t >(p->get_id())];
+    int bt = bubble_id[static_cast< size_t >(transmitter->get_id())];
+
+    if ((bp < 0) || (bt < 0))
+        return 0.0;
+
+    // Contacts inside the bubble are exactly what the policy keeps: they are
+    // left alone.
+    if (bp == bt)
+        return 0.0;
+
+    // Contacts outside the bubble are scaled by the transmission factor:
+    // 0 = perfectly observed bubble (contact cut), 1 = the bubble imposes
+    // nothing.
+    epiworld_double factor = model->par(param_name);
+    if (factor <= 0.0)
+        return 1.0;
+    if (factor >= 1.0)
+        return 0.0;
+
+    return static_cast<epiworld_double>(1.0) - factor;
+
+}
+
+template<typename TSeq>
+inline void Bubbles<TSeq>::operator()(Model<TSeq> * model, int day)
+{
+
+    // Only rewiring needs a daily event; the tool gates itself by day, and the
+    // epoch-0 partition is computed at reset (see deploy()). Because global
+    // events run after update_state(), a rewired partition takes effect the
+    // following simulation step.
+    if (rewire_every <= 0)
+        return;
+
+    if (!is_active(day))
+        return;
+
+    int sim   = static_cast< int >(model->get_sim_id());
+    int epoch = (day - start_day) / rewire_every;
+
+    // Already up to date for this (replicate, epoch).
+    if ((last_sim_id == sim) && (last_epoch == epoch))
+        return;
+
+    compute_partition(model);
+    last_sim_id = sim;
+    last_epoch  = epoch;
 
 }
 
@@ -335,129 +452,74 @@ inline void Bubbles<TSeq>::deploy(Model<TSeq> & model)
     // mid-run through the model's parameters.
     model.add_param(transmission_factor, param_name, true);
 
-    // ---- The bubble tool: dampens out-of-bubble transmission ---------------
-    auto st  = state;
-    int  sd  = start_day;
-    int  ed  = end_day;
-    std::string pname = param_name;
+    // ---- The intervention itself -------------------------------------------
+    // add_globalevent() clones this object, so the model owns the partition and
+    // the rewiring schedule. Copies of the model (e.g. the per-thread copies
+    // made by run_multiple) clone it again and are fully independent.
+    model.add_globalevent(*this);
 
-    Tool<TSeq> bubble_tool(name);
-    bubble_tool.set_susceptibility_reduction_fun(
-        [st, sd, ed, pname](
-            Tool<TSeq> &,
-            Agent<TSeq> * p,
-            VirusPtr<TSeq> & v,
-            Model<TSeq> * m
-        ) -> epiworld_double {
+    // ---- The tool: dampens out-of-bubble transmission -----------------------
+    // It carries no state of its own: it finds the model's intervention by name
+    // the first time it is used.
+    BubbleTool<TSeq> bubble_tool(this->get_name(), this->get_name());
 
-            int today = static_cast< int >(m->today());
-
-            // Policy window.
-            if (today < sd)
-                return 0.0;
-            if ((ed >= 0) && (today >= ed))
-                return 0.0;
-
-            if (st->bubble_id.empty())
-                return 0.0;
-
-            Agent<TSeq> * transmitter = v->get_agent();
-            if (transmitter == nullptr)
-                return 0.0;
-
-            int bp = st->bubble_id[static_cast< size_t >(p->get_id())];
-            int bt = st->bubble_id[static_cast< size_t >(transmitter->get_id())];
-
-            if ((bp < 0) || (bt < 0))
-                return 0.0;
-
-            // Contacts inside the bubble are exactly what the policy keeps:
-            // they are left alone.
-            if (bp == bt)
-                return 0.0;
-
-            // Contacts outside the bubble are scaled by the transmission
-            // factor: 0 = perfectly observed bubble (contact cut), 1 = the
-            // bubble imposes nothing.
-            epiworld_double factor = m->par(pname);
-            if (factor <= 0.0)
-                return 1.0;
-            if (factor >= 1.0)
-                return 0.0;
-
-            return static_cast<epiworld_double>(1.0) - factor;
-
-        }
-    );
-
-    // ---- Distribution: recompute the partition at reset time ---------------
+    // ---- Distribution: recompute the partition at reset time ----------------
     // The tool's distribution function runs from Model::reset() -> dist_tools(),
     // i.e. *before* day 1 and with the run's (per-replicate) RNG already seeded.
     // Computing the partition here — rather than eagerly in deploy() — keeps the
     // epoch-0 partition fresh for every replicate of run_multiple() and avoids
     // any dependence on a stale partition left over from a previous run. It then
     // distributes the tool to every agent (prevalence 1.0).
-    Bubbles<TSeq> self = *this; // shares `state` via the shared_ptr
+    std::string ename = this->get_name();
     ToolToAgentFun<TSeq> distribute_all = distribute_tool_randomly<TSeq>(1.0, true);
     bubble_tool.set_distribution(
-        [self, distribute_all](Tool<TSeq> & tool, Model<TSeq> * m) -> void {
-            self.compute_partition(m);
-            self.state->last_sim_id = static_cast< int >(m->get_sim_id());
-            self.state->last_epoch  = 0;
+        [ename, distribute_all](Tool<TSeq> & tool, Model<TSeq> * m) -> void {
+
+            Bubbles<TSeq> * self = Bubbles<TSeq>::get_from(*m, ename);
+
+            if (self == nullptr)
+                throw std::logic_error(
+                    "Bubbles: the intervention '" + ename +
+                    "' is not installed on this model."
+                );
+
+            self->compute_partition(m);
+            self->last_sim_id = static_cast< int >(m->get_sim_id());
+            self->last_epoch  = 0;
+
             distribute_all(tool, m);
+
         }
     );
 
     model.add_tool(bubble_tool);
 
-    // ---- The scheduler: re-randomizes the partition at rewiring epochs -----
-    // The epoch-0 partition is installed at reset (above); this event only
-    // handles rewire_every > 0, recomputing when the epoch advances. Because
-    // global events run after update_state(), a rewired partition takes effect
-    // the following simulation step. Deactivation (end_day) needs no event: the
-    // tool gates itself by day.
-    if (rewire_every > 0)
-    {
-        model.add_globalevent(
-            [self](Model<TSeq> * m) -> void {
-
-                int today = static_cast< int >(m->today());
-
-                bool on = (today >= self.start_day) &&
-                    ((self.end_day < 0) || (today < self.end_day));
-                if (!on)
-                    return;
-
-                int sim   = static_cast< int >(m->get_sim_id());
-                int epoch = (today - self.start_day) / self.rewire_every;
-
-                // Already up to date for this (replicate, epoch).
-                if ((self.state->last_sim_id == sim) &&
-                    (self.state->last_epoch == epoch))
-                    return;
-
-                self.compute_partition(m);
-                self.state->last_sim_id = sim;
-                self.state->last_epoch  = epoch;
-
-            },
-            name + " (scheduler)",
-            -99
-        );
-    }
-
 }
 
 template<typename TSeq>
-inline std::shared_ptr< BubbleState > Bubbles<TSeq>::get_state() const
+inline Bubbles<TSeq> * Bubbles<TSeq>::get_from(
+    Model<TSeq> & model,
+    const std::string & name
+)
 {
-    return state;
+
+    if (!model.has_globalevent(name))
+        return nullptr;
+
+    return dynamic_cast< Bubbles<TSeq> * >(&model.get_globalevent(name));
+
 }
 
 template<typename TSeq>
 inline const std::vector< int > & Bubbles<TSeq>::get_bubble_id() const
 {
-    return state->bubble_id;
+    return bubble_id;
+}
+
+template<typename TSeq>
+inline int Bubbles<TSeq>::get_last_epoch() const
+{
+    return last_epoch;
 }
 
 template<typename TSeq>
@@ -470,6 +532,12 @@ template<typename TSeq>
 inline const std::string & Bubbles<TSeq>::get_param_name() const
 {
     return param_name;
+}
+
+template<typename TSeq>
+inline std::unique_ptr< GlobalEvent<TSeq> > Bubbles<TSeq>::clone_ptr() const
+{
+    return std::make_unique< Bubbles<TSeq> >(*this);
 }
 
 #endif

--- a/inst/include/epiworld/model-bones.hpp
+++ b/inst/include/epiworld/model-bones.hpp
@@ -751,6 +751,7 @@ public:
 
     GlobalEvent<TSeq> & get_globalevent(std::string name); ///< Retrieve a global action by name
     GlobalEvent<TSeq> & get_globalevent(size_t i); ///< Retrieve a global action by index
+    bool has_globalevent(std::string_view name) const; ///< Whether a global action by that name exists
 
     void rm_globalevent(std::string name); ///< Remove a global action by name
     void rm_globalevent(size_t i); ///< Remove a global action by index

--- a/inst/include/epiworld/model-bones.hpp
+++ b/inst/include/epiworld/model-bones.hpp
@@ -704,6 +704,7 @@ public:
     );
     Model<TSeq> & read_params(std::string fn, bool overwrite = false);
     epiworld_double get_param(std::string pname);
+    bool has_param(std::string_view pname) const;
     void set_param(std::string pname, epiworld_double val);
     epiworld_double par(std::string pname) const;
     ///@}

--- a/inst/include/epiworld/model-meat.hpp
+++ b/inst/include/epiworld/model-meat.hpp
@@ -2231,11 +2231,20 @@ GlobalEvent<TSeq> & Model<TSeq>::get_globalevent(
 {
 
     for (auto & a : globalevents)
-        if (a.name == name)
-            return a;
+        if (a->get_name() == name)
+            return *a;
 
     throw std::logic_error("The global action " + name + " was not found.");
 
+}
+
+template<typename TSeq>
+inline bool Model<TSeq>::has_globalevent(std::string_view name) const
+{
+    for (const auto & a : globalevents)
+        if (a->get_name() == name)
+            return true;
+    return false;
 }
 
 template<typename TSeq>
@@ -2605,7 +2614,20 @@ inline bool Model<TSeq>::operator==(const Model<TSeq> & other) const
         "Model:: current_date don't match"
     )
 
-    VECT_MATCH(globalevents, other.globalevents, "global action don't match");
+    // Global events are held by pointer and deep-copied when a model is copied,
+    // so they must be compared through the pointer (as viruses and tools are).
+    EPI_DEBUG_FAIL_AT_TRUE(
+        globalevents.size() != other.globalevents.size(),
+        "Model:: globalevents.size() don't match"
+    )
+
+    for (size_t i = 0u; i < globalevents.size(); ++i)
+    {
+        EPI_DEBUG_FAIL_AT_TRUE(
+            *globalevents[i] != *other.globalevents[i],
+            "Model:: *globalevents[i] don't match"
+        )
+    }
 
     EPI_DEBUG_FAIL_AT_TRUE(
         queue != other.queue,

--- a/inst/include/epiworld/model-meat.hpp
+++ b/inst/include/epiworld/model-meat.hpp
@@ -1915,6 +1915,16 @@ inline void Model<TSeq>::reset() {
     // Distributing initial state, if specified
     initial_states_fun(this);
 
+    // Global events set themselves up for the run. This happens last, with the
+    // RNG seeded and the population in its initial state, so that an event that
+    // needs to act on the model it is running in (e.g. one that hands a tool to
+    // every agent) is in force from day 1 -- global events themselves only run
+    // *after* each day's transitions.
+    for (auto & event : globalevents)
+        event->reset(this);
+
+    events_run();
+
     // Recording day 0 and advancing to day 1 is handled by Model::run().
     // Keeping reset() side-effect free from virtual next() prevents
     // derived-model update code from running before derived reset state
@@ -2078,6 +2088,12 @@ inline epiworld_double Model<TSeq>::get_param(std::string pname)
         throw std::logic_error("The parameter " + pname + " does not exists.");
 
     return parameters[pname];
+}
+
+template<typename TSeq>
+inline bool Model<TSeq>::has_param(std::string_view pname) const
+{
+    return parameters.find(std::string(pname)) != parameters.end();
 }
 
 template<typename TSeq>

--- a/inst/tinytest/test-bubbles.R
+++ b/inst/tinytest/test-bubbles.R
@@ -135,6 +135,37 @@ expect_true(sum(hh_of(sec_p$source) != hh_of(sec_p$target)) > 0)
 expect_true(sum(hh_of(sec_p$source) == hh_of(sec_p$target)) > 0)
 
 ###############################################################################
+# Replicates are independent: the partition belongs to the model, so the
+# per-thread copies run_multiple() makes each keep their own. Running on two
+# threads must give exactly the same replicates as running on one, and must not
+# make the model single-threaded.
+###############################################################################
+model_mt <- ModelSEIR("Flu", 0.05, 0.3, 4.5, 1 / 7)
+agents_smallworld(model_mt, n = 600, k = 8, d = FALSE, p = 0.10)
+bubbles(model_mt, household_id = hh, flavor = "household", group_size = 2,
+        transmission_factor = 0.0, start_day = 0)
+
+expect_null(attr(model_mt, "single_threaded"))
+
+outbreak_sizes <- function(m, nthreads) {
+  saver <- make_saver("total_hist")
+  # No warning about parallel execution: nothing is shared between copies.
+  expect_silent(
+    run_multiple(m, ndays = 40, nsims = 4, seed = 3311, saver = saver,
+                 verbose = FALSE, nthreads = nthreads)
+  )
+  res <- run_multiple_get_results(m, nthreads = nthreads)$total_hist
+  res <- res[res$date == 40 & res$state == "Recovered", ]
+  res$counts[order(res$sim_num)]
+}
+
+serial_sizes   <- outbreak_sizes(model_mt, 1L)
+parallel_sizes <- outbreak_sizes(model_mt, 2L)
+
+expect_true(all(serial_sizes > 0))
+expect_equal(parallel_sizes, serial_sizes)
+
+###############################################################################
 # Input validation.
 ###############################################################################
 model_v <- ModelSEIR("Flu", 0.05, 0.2, 4.5, 1 / 7)

--- a/man/bubbles.Rd
+++ b/man/bubbles.Rd
@@ -188,9 +188,11 @@ every contact was taken first stay on their own.
 
 The bubbles are drawn afresh at the start of every run, using that run's seed,
 and are already in force on day 1. With \code{rewire_every > 0} they are redrawn
-during the run, taking effect the following day. Because the intervention
-keeps a single shared state, replicates with \link{run_multiple} must use one
-thread (\code{nthreads = 1}); \code{bubbles()} flags the model accordingly.
+during the run, taking effect the following day.
+
+The partition belongs to the model rather than to the intervention, so each
+of the per-thread copies of the model that \code{\link[=run_multiple]{run_multiple()}} makes draws and
+keeps its own. Replicates may run on as many threads as you like.
 }
 
 \subsection{What this cannot represent}{

--- a/src/bubbles.cpp
+++ b/src/bubbles.cpp
@@ -40,12 +40,21 @@ SEXP bubbles_cpp(
     param_name
   );
 
-  // deploy() installs the bubble tool and the scheduler event on the model, and
-  // registers `param_name` as a model parameter holding the transmission factor
-  // (the tool reads it from the model on every exposure).
-  // The intervention's shared state is kept alive by the closures captured in
-  // those objects, so the local `bubbles` can safely go out of scope.
-  bubbles.deploy(*modelptr);
+  // Registering the transmission factor as a model parameter here, rather than
+  // leaving it to the intervention (which does it at the start of each run), is
+  // what lets get_param()/set_param() reach it as soon as bubbles() returns.
+  // The intervention keeps whatever value the model already holds, so a
+  // set_param() before run() governs the run.
+  modelptr->add_param(
+    static_cast< epiworld_double >(transmission_factor), param_name, true
+  );
+
+  // The model is handed a clone of the intervention, which then installs
+  // itself -- the bubble tool, the partition, and the rewiring schedule -- on
+  // the model at the start of every run, including each replicate of
+  // run_multiple(). The local `bubbles` is only a template, so it can safely go
+  // out of scope.
+  modelptr->add_globalevent(bubbles);
 
   return model;
 

--- a/vignettes/bubbles.qmd
+++ b/vignettes/bubbles.qmd
@@ -101,12 +101,12 @@ run_scenario <- function(model, policy) {
     seed     = simulation_seed,
     saver    = saver,
     verbose  = FALSE,
-    nthreads = 1L
+    nthreads = 2L
   )
 
   outbreak <- run_multiple_get_results(
     model,
-    nthreads = 1L
+    nthreads = 2L
   )$outbreak_size
 
   final <- outbreak[outbreak$date == ndays, ]
@@ -223,8 +223,9 @@ bubbles(
 # Compare outbreak sizes
 
 Finally, we run 200 replicates for each scenario and report the final outbreak
-size. Bubble models must use one thread because the intervention maintains
-shared state; `bubbles()` marks them accordingly.
+size. Each replicate draws its own bubbles from its own seed, and the partition
+belongs to the model rather than to the intervention, so the replicates can be
+spread across threads.
 
 ```{r}
 #| label: run-scenarios


### PR DESCRIPTION
Syncs epiworld's reworked Bubbles intervention. The bubble partition used to sit in a shared object captured by the tool's callbacks, so the per-thread copies of the model that run_multiple() makes all wrote into it. The intervention is now the model's own global event and the tool resolves to whichever model it belongs to, so every copy keeps its own bubbles.

`bubbles()` therefore no longer marks the model single-threaded (that flag stays for `globalevent_fun()`, whose R callbacks genuinely cannot be threaded). The vignette runs its replicates on two threads, and the tinytest suite checks that one and two threads give identical replicates and that no warning is raised.