### PR TITLE
Add pkgdown author profiles

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,15 @@ url: ~
 template:
   bootstrap: 5
 
+authors:
+  "George Vega Yon":
+    href: "https://ggvy.cl"
+    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"
+  "Derek Meyer":
+    href: "https://orcid.org/0009-0005-1350-6988"
+  "Andrew Pulsipher":
+    href: "https://orcid.org/0000-0002-0773-3210"
+
 reference:
   - title: "General Models"
     desc: >

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,7 +5,6 @@ template:
 authors:
   "George Vega Yon":
     href: "https://ggvy.cl"
-    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"
   "Derek Meyer":
     href: "https://orcid.org/0009-0005-1350-6988"
   "Andrew Pulsipher":


### PR DESCRIPTION
## Summary

- link George Vega Yon to https://ggvy.cl while preserving his displayed name
- add profile links for every package author listed in DESCRIPTION
- add a source pkgdown configuration where the published site did not already have one

## Validation

- loaded the package metadata with pkgdown
- verified exact author-name matching against DESCRIPTION
- verified every configured author mapping contains only an href attribute

Related to gvegayon/website#32.